### PR TITLE
Add restrictions on modifiers in local scope

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -84,7 +84,7 @@ internal open class Test {
 
 (source_file
     (class_declaration
-        (modifiers (visibility_modifier) (inheritance_modifier))
+        (modifiers (visibility_modifier) (visibility_modifier))
         (type_identifier)
         (class_body
             (property_declaration
@@ -159,7 +159,7 @@ class GenericSubscript {
         (type_identifier)
         (class_body
             (subscript_declaration
-                (modifiers (inheritance_modifier))
+                (modifiers (visibility_modifier))
                 (parameter (simple_identifier) (user_type (type_identifier)))
                 (optional_type (user_type (type_identifier)))
                 (computed_getter
@@ -201,40 +201,45 @@ class GenericSubscript {
 Subscript with multiple arguments
 ===
 
-public subscript<D>(_ value: D, arg2: Arg2) -> D where D: Decodable {
-    return value
+class Subscriptable {
+    public subscript<D>(_ value: D, arg2: Arg2) -> D where D: Decodable {
+        return value
+    }
 }
 
 ---
 
-(source_file
-  (subscript_declaration
-    (modifiers
-      (visibility_modifier))
-    (type_parameters
-      (type_parameter
-        (type_identifier)))
-    (external_parameter_name)
-    (parameter
-      (simple_identifier)
-      (user_type
-        (type_identifier)))
-    (parameter
-      (simple_identifier)
-      (user_type
-        (type_identifier)))
-    (user_type
-      (type_identifier))
-    (type_constraints
-      (type_constraint
-        (inheritance_constraint
-          (identifier
-            (simple_identifier))
-          (user_type
-            (type_identifier)))))
-    (statements
-      (control_transfer_statement
-        (simple_identifier)))))
+    (source_file
+      (class_declaration
+        (type_identifier)
+        (class_body
+          (subscript_declaration
+            (modifiers
+              (visibility_modifier))
+            (type_parameters
+              (type_parameter
+                (type_identifier)))
+            (external_parameter_name)
+            (parameter
+              (simple_identifier)
+              (user_type
+                (type_identifier)))
+            (parameter
+              (simple_identifier)
+              (user_type
+                (type_identifier)))
+            (user_type
+              (type_identifier))
+            (type_constraints
+              (type_constraint
+                (inheritance_constraint
+                  (identifier
+                    (simple_identifier))
+                  (user_type
+                    (type_identifier)))))
+            (statements
+              (control_transfer_statement
+                (simple_identifier)))))))
 
 ==================
 Inheritance
@@ -303,7 +308,7 @@ class SomethingElse: ThingProvider {
                 (type_annotation
                     (optional_type (user_type (type_identifier)))))
             (property_declaration
-                (modifiers (property_modifier))
+                (modifiers (property_behavior_modifier))
                 (value_binding_pattern (non_binding_pattern (simple_identifier)))
                 (type_annotation
                 (user_type (type_identifier)))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -110,15 +110,19 @@ someVeryLongFunctionCall()
 Multiple expressions on one line using semicolons
 ==================
 
-print(a); return b
+print(a); throw b
 
 ---
 
-(source_file
-    (call_expression
+    (source_file
+      (call_expression
         (simple_identifier)
-        (call_suffix (value_arguments (value_argument (simple_identifier)))))
-    (control_transfer_statement (simple_identifier)))
+        (call_suffix
+          (value_arguments
+            (value_argument
+              (simple_identifier)))))
+      (throw_keyword)
+      (simple_identifier))
 
 ==================
 Indexing
@@ -230,20 +234,37 @@ let a: SomeClass = .someInstance
 Tuple expressions
 ==================
 
-let a: (Int, Int) = (1, 2)
-return (lhs: 3, rhs: 4)
+func math() {
+    let a: (Int, Int) = (1, 2)
+    return (lhs: 3, rhs: 4)
+}
 
 ---
 
-(source_file
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (type_annotation (tuple_type (user_type (type_identifier)) (user_type (type_identifier))))
-        (tuple_expression (integer_literal) (integer_literal)))
-    (control_transfer_statement
-        (tuple_expression
-            (simple_identifier) (integer_literal)
-            (simple_identifier) (integer_literal))))
+    (source_file
+      (function_declaration
+        (simple_identifier)
+        (function_body
+          (statements
+            (property_declaration
+              (value_binding_pattern
+                (non_binding_pattern
+                  (simple_identifier)))
+              (type_annotation
+                (tuple_type
+                  (user_type
+                    (type_identifier))
+                  (user_type
+                    (type_identifier))))
+              (tuple_expression
+                (integer_literal)
+                (integer_literal)))
+            (control_transfer_statement
+              (tuple_expression
+                (simple_identifier)
+                (integer_literal)
+                (simple_identifier)
+                (integer_literal)))))))
 
 ==================
 Function calls

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -390,7 +390,7 @@ test { [weak self, otherSelf] (a) in }
         (simple_identifier)
         (call_suffix
             (lambda_literal
-                (capture_list (simple_identifier) (simple_identifier))
+                (capture_list (ownership_modifier) (simple_identifier) (simple_identifier))
                 (lambda_function_type (lambda_function_type_parameters (simple_identifier)))))))
 
 ==================
@@ -469,7 +469,7 @@ private lazy var onCatClosure: (_ cat: Cat) throws -> Void = { _ in
 
 (source_file
     (property_declaration
-        (modifiers (visibility_modifier) (property_modifier))
+        (modifiers (visibility_modifier) (property_behavior_modifier))
         (value_binding_pattern (non_binding_pattern (simple_identifier)))
         (type_annotation
             (function_type

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -356,25 +356,39 @@ someLabel: if a.isEmpty, let b = getB() {
 If let with function call
 ===============
 
-if let a = try? Foo.getValue("key") {
-    return a
+func doSomething() {
+    if let a = try? Foo.getValue("key") {
+        return a
+    }
+    return default
 }
-return default
 
 ---
 
-(source_file
-    (if_statement
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (call_expression
-            (try_expression
-                (navigation_expression (simple_identifier)
-                    (navigation_suffix (simple_identifier))))
-            (call_suffix
-                (value_arguments
-                    (value_argument (line_string_literal)))))
-        (statements (control_transfer_statement (simple_identifier))))
-    (control_transfer_statement (simple_identifier)))
+    (source_file
+      (function_declaration
+        (simple_identifier)
+        (function_body
+          (statements
+            (if_statement
+              (value_binding_pattern
+                (non_binding_pattern
+                  (simple_identifier)))
+              (call_expression
+                (try_expression
+                  (navigation_expression
+                    (simple_identifier)
+                    (navigation_suffix
+                      (simple_identifier))))
+                (call_suffix
+                  (value_arguments
+                    (value_argument
+                      (line_string_literal)))))
+              (statements
+                (control_transfer_statement
+                  (simple_identifier))))
+            (control_transfer_statement
+              (simple_identifier))))))
 
 ==================
 Compound if let
@@ -531,3 +545,52 @@ let ø = unicode()
       (simple_identifier)
       (call_suffix
         (value_arguments)))))
+
+===
+Contextual keywords are usable as identifiers
+===
+
+public init() {
+    // `prefix` doesn't work as a function modifier here, so it's legal as an identifier
+    prefix = prefixToJSON
+
+    // But some modifiers are legal!
+    weak var weakPrefix = prefix
+    final class LocalClass { }
+
+    // Annotations are legal too!
+    @someAnnotation
+    func innerFunc() { }
+}
+
+---
+
+(source_file
+  (function_declaration
+    (modifiers
+      (visibility_modifier))
+    (function_body
+      (comment)
+      (statements
+        (assignment
+          (directly_assignable_expression
+            (simple_identifier))
+          (simple_identifier))
+        (comment)
+        (property_declaration
+          (ownership_modifier)
+          (value_binding_pattern
+            (non_binding_pattern
+              (simple_identifier)))
+          (simple_identifier))
+        (class_declaration
+          (inheritance_modifier)
+          (type_identifier)
+          (class_body))
+        (comment)
+        (function_declaration
+          (attribute
+            (user_type
+              (type_identifier)))
+          (simple_identifier)
+          (function_body))))))

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -7,12 +7,10 @@ Carthage/Source/carthage/Build.swift
 Carthage/Source/carthage/Checkout.swift
 Carthage/Source/carthage/Formatting.swift
 Carthage/Source/CarthageKit/Archive.swift
-Carthage/Source/CarthageKit/VersionFile.swift
 Carthage/Source/CarthageKit/Project.swift
 Carthage/Source/CarthageKit/GitURL.swift
 Carthage/Source/CarthageKit/Git.swift
 Carthage/Tests/CarthageKitTests/DependencySpec.swift
 Carthage/Tests/CarthageKitTests/CartfileCommentsSpec.swift
 ObjectMapper/Package@swift-4.swift
-ObjectMapper/Sources/HexColorTransform.swift
 ObjectMapper/Sources/ToJSON.swift


### PR DESCRIPTION
Declarations for functions, classes, and variables are legal at various
different scopes (global, type-level, and local), but have different
sets of legal modifiers in each. While you might think that would be
fine and would simply improve our permissiveness, it actually ends up
_restricting_ some valid code - in particular, code that uses those
would-be modifiers as identifiers. For instance, one file in Carthage
uses the innocent-looking variable name `prefix`, but we fail to parse
that because in other scopes, that would instead be a modifier.

To fix this, we split out declarations by scope: global, type-level, and
local. For now, we treat global and type-level as mostly the same except
that subscripts are legal in the latter and not the former. However, for
local declarations, we allow a much smaller list of operators.

Fixes #39
