### PR TITLE
Minorly improve custom operator handling

### DIFF
--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,11 +1,5 @@
-Carthage/Source/carthage/Outdated.swift
-Carthage/Source/carthage/Archive.swift
-Carthage/Source/carthage/Update.swift
 Carthage/Source/carthage/Extensions.swift
-Carthage/Source/carthage/Fetch.swift
 Carthage/Source/carthage/Build.swift
-Carthage/Source/carthage/Checkout.swift
-Carthage/Source/carthage/Formatting.swift
 Carthage/Source/CarthageKit/Archive.swift
 Carthage/Source/CarthageKit/Project.swift
 Carthage/Source/CarthageKit/GitURL.swift


### PR DESCRIPTION
We still need to move the custom operator logic to the scanner, but
that's a lot of complexity, and it's still unclear how to do that
without a lot of breakage. Instead of doing that now, we just special
case handling of `<` (which is what was tripping up a lot of Carthage
files).

With this change, #5 will no longer be a top-repos-error, even though it
will still be a valid bug.
