### PR TITLE
Make check expressions behave properly

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -634,3 +634,27 @@ print(thing.maybeGreeting!.definitely)
                 (simple_identifier)))
             (navigation_suffix
               (simple_identifier))))))))
+
+===
+Check expression
+===
+
+checkThat(dict is Dictionary<Foo, Bar>)
+
+---
+
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (check_expression
+            (simple_identifier)
+            (user_type
+              (type_identifier)
+              (type_arguments
+                (user_type
+                  (type_identifier))
+                (user_type
+                  (type_identifier))))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -486,7 +486,7 @@ module.exports = grammar({
       ),
 
     check_expression: ($) =>
-      prec.left(PREC.CHECK, seq($._expression, $._is_operator, $._expression)),
+      prec.left(PREC.CHECK, seq($._expression, $._is_operator, $._type)),
 
     comparison_expression: ($) =>
       prec.left(seq($._expression, $._comparison_operator, $._expression)),


### PR DESCRIPTION
The right hand side of an `is` should be a type, not an expression.

Fixes #49
