### PR TITLE
Don't emit a built-in operator if it could be a prefix for a custom one

### DIFF
--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -261,6 +261,24 @@ infix operator -=- : MyPrecedence
             (precedence_group_attribute (simple_identifier) (simple_identifier))))
     (operator_declaration (custom_operator) (simple_identifier)))
 
+===
+Custom operator with another operator as a prefix
+===
+
+let messageCoerced = error ??? "nil"
+
+---
+
+(source_file
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (infix_expression
+      (simple_identifier)
+      (custom_operator)
+      (line_string_literal))))
+
 ==================
 Functions that throw
 ==================

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -40,22 +40,6 @@ const char* CROSS_SEMI_OPERATORS[CROSS_SEMI_OPERATOR_COUNT] = {
     "else"
 };
 
-const int32_t CROSS_SEMI_OP_LENS[CROSS_SEMI_OPERATOR_COUNT] = {
-    2,
-    1,
-    3,
-    3,
-    2,
-    2,
-    2,
-    1,
-    6,
-    8,
-    7,
-    5,
-    4
-};
-
 const enum TokenType CROSS_SEMI_SYMBOLS[CROSS_SEMI_OPERATOR_COUNT] = {
     ARROW_OPERATOR,
     DOT_OPERATOR,
@@ -187,14 +171,33 @@ static bool eat_operators(
                 continue;
             }
 
-            if (str_idx > CROSS_SEMI_OP_LENS[op_idx]) {
-                possible_operators[op_idx] = false;
-                continue;
-            }
+            if (CROSS_SEMI_OPERATORS[op_idx][str_idx] == '\0') {
+                switch (lexer->lookahead) {
+                // See "Operators":
+                // https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html#ID418
+                case '/':
+                case '=':
+                case '-':
+                case '+':
+                case '!':
+                case '*':
+                case '%':
+                case '<':
+                case '>':
+                case '&':
+                case '|':
+                case '^':
+                case '?':
+                case '~':
+                    break;
+                default:
+                    // Only match if this is the _end_ of an operator. If it's possible for a custom
+                    // operator to continue from here, don't treat it as a full match.
+                    full_match = op_idx;
+                    lexer->mark_end(lexer);
+                }
 
-            if (str_idx == CROSS_SEMI_OP_LENS[op_idx]) {
-                full_match = op_idx;
-                lexer->mark_end(lexer);
+                possible_operators[op_idx] = false;
                 continue;
             }
 


### PR DESCRIPTION
It's possible to define a custom operator like `???`, even though that
starts with the built-in nil coalescing operator. Our custom scanner
doesn't allow this today. What we need to do is check whether the
character _after_ the end of a built-in operator is a valid continuing
character for a custom operator, and only emit the built-in operator if
it isn't.

For simplicity, this doesn't handle all of the unicode characters that
are allowed in a custom operator, because they mostly don't get used.
When we move the custom operator handling _fully_ to the custom scanner,
that's probably the right time to revisit this.

Fixes #45
