### PR TITLE
Treat assignment as an expression

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -278,7 +278,7 @@ class Something {
     }
     var z: Int {
         get { v }
-        set { v = newValue }
+        set { return v = newValue }
     }
 }
 
@@ -331,7 +331,11 @@ class SomethingElse: ThingProvider {
                 (type_annotation (user_type (type_identifier)))
                 (computed_property
                     (computed_getter (getter_specifier) (statements (simple_identifier)))
-                    (computed_setter (setter_specifier) (statements (assignment (directly_assignable_expression (simple_identifier)) (simple_identifier))))))))
+                    (computed_setter
+                        (setter_specifier)
+                        (statements
+                            (control_transfer_statement
+                                (assignment (directly_assignable_expression (simple_identifier)) (simple_identifier)))))))))
     (class_declaration
         (type_identifier)
         (inheritance_specifier (user_type (type_identifier)))

--- a/grammar.js
+++ b/grammar.js
@@ -37,8 +37,8 @@ const PREC = {
   CONJUNCTION: 4,
   DISJUNCTION: 3,
   RANGE: 2,
-  ASSIGNMENT: 1,
   BLOCK: 1,
+  ASSIGNMENT: -1,
   COMMENT: -1,
   LAMBDA_LITERAL: -1,
 };
@@ -366,6 +366,7 @@ module.exports = grammar({
         $._binary_expression,
         $.ternary_expression,
         $._primary_expression,
+        $.assignment,
         seq($._expression, $._immediate_quest)
       ),
 
@@ -771,7 +772,7 @@ module.exports = grammar({
         seq(
           // XXX associativity or precedence seems wrong here
           $._try_operator,
-          choice($._expression, $.assignment)
+          $._expression
         )
       ),
 
@@ -867,8 +868,7 @@ module.exports = grammar({
         $._expression,
         $._local_declaration,
         $._labeled_statement,
-        $.control_transfer_statement,
-        $.assignment
+        $.control_transfer_statement
       ),
 
     _top_level_statement: ($) =>
@@ -876,8 +876,7 @@ module.exports = grammar({
         $._expression,
         $._global_declaration,
         $._labeled_statement,
-        $._throw_statement,
-        $.assignment
+        $._throw_statement
       ),
 
     _block: ($) => prec(PREC.BLOCK, seq("{", optional($.statements), "}")),


### PR DESCRIPTION
Swift allows `return a = b` and stuff like that. We can do that too, we
just have to move some definitions around and change precedence.
