### PR TITLE
Parallelize locally and allow split repositories

### DIFF
--- a/.github/workflows/top-repos.yml
+++ b/.github/workflows/top-repos.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        repo: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        repo: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
 
     steps:
     - uses: actions/checkout@v2

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -8,3 +8,6 @@ Carthage/Tests/CarthageKitTests/DependencySpec.swift
 Carthage/Tests/CarthageKitTests/CartfileCommentsSpec.swift
 ObjectMapper/Package@swift-4.swift
 ObjectMapper/Sources/ToJSON.swift
+firefox-ios/Shared/Functions.swift
+firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
+firefox-ios/Client/Frontend/Browser/Authenticator.swift

--- a/script-data/top-repositories.txt
+++ b/script-data/top-repositories.txt
@@ -7,3 +7,9 @@ shadowsocks shadowsocks/ShadowsocksX-NG v1.9.4
 Carthage Carthage/Carthage 0.38.0
 Moya Moya/Moya 15.0.0
 ObjectMapper tristanhimmelman/ObjectMapper 3.5.3
+firefox-ios mozilla-mobile/firefox-ios v39.0 0 6
+firefox-ios mozilla-mobile/firefox-ios v39.0 1 6
+firefox-ios mozilla-mobile/firefox-ios v39.0 2 6
+firefox-ios mozilla-mobile/firefox-ios v39.0 3 6
+firefox-ios mozilla-mobile/firefox-ios v39.0 4 6
+firefox-ios mozilla-mobile/firefox-ios v39.0 5 6

--- a/scripts/top-repos.sh
+++ b/scripts/top-repos.sh
@@ -28,9 +28,9 @@ function checkout() {
 
   if [ ! -d "$repo" ]; then
     git clone --quiet --branch $tag --depth 1 "https://github.com/$url" "$repo" >/dev/null 2>/dev/null
-  fi
 
-  echo "Cloned repository into $(pwd)/$repo"
+    echo "Cloned repository into $(pwd)/$repo"
+  fi
 }
 
 # Function to validate that a passed-in git repository can be parsed using this parser.
@@ -38,27 +38,51 @@ function checkout() {
 # If the passed-in repository fails to parse in ways that do not match the `known_failures` script
 # data, this prints info about the failure and exits the script with a nonzero status code.
 function validate() {
-  repo=$1; url=$2; tag=$3
+  repo=$1; url=$2; tag=$3; part=$4; total=$5
 
-  cd $tmpdir
-  checkout $repo $url $tag
-  cd $parser_dir
+  if [ -z "$part" ] || [ -z "$total" ]; then
+    part=0
+    total=1
+  fi
 
-  all_files=$(find "$tmpdir/$repo" -name *.swift -not -path '*/Pods/*')
+  data_dir=$tmpdir/.$repo-data-$part
+  mkdir -p $data_dir || true
+
+  # Find the start and end of this section based on the passed-in `part` and `total`.
+  all_files=$data_dir/all_files.txt
+  find "$tmpdir/$repo" -name *.swift -not -path '*/Pods/*' > $all_files
+  file_count=$(wc -l < $all_files | tr -d ' ')
+
+  one_past_the_end=$((file_count + 1))
+  start=$(($((one_past_the_end * part)) / total))
+  next_part=$((part + 1))
+  next_start=$(($((one_past_the_end * next_part)) / total))
+  end=$((next_start - 1))
+  len=$((end - start))
+
   failed_files=$(
     IFS=$'\n'
-    for file in $all_files; do
+    for file in $(head -$end < $all_files | tail -$len); do
        npx tree-sitter parse -q "$file" 2>/dev/null
     done | { grep -v -f "$known_failures" || true; }
     unset IFS
   )
 
   if [[ "$failed_files" = *[![:space:]]* ]]; then
-    echo "Unexpected parse failure found in $repo:"
+    echo -en "Unexpected parse failure found in $repo "
+    if [ -z $4 ]; then
+        echo ":"
+    else
+        echo "block $start-$end:"
+    fi
+
     cat <<<"$failed_files"
+
     exit 1
-  else
+  elif [ -z $4 ]; then
     echo "Parsed $repo successfully!"
+  else
+    echo "Parsed $repo files $start-$end of $file_count successfully!"
   fi
 }
 
@@ -72,5 +96,13 @@ fi
 
 # Run `validate` on every repository in `top-repositories` sequentially.
 while read line ; do
-    validate $line
+    cd $tmpdir
+    checkout $line
+    cd $parser_dir
+    validate $line &
+    pids+=($!)
 done <<<"$repos"
+
+for pid in "${pids[@]}" ; do
+    wait $pid
+done


### PR DESCRIPTION
Adding functionality to specify "part X of Y" of a repository. This
allows two things to happen:
1. In CI, that repository will get split across multiple Github Actions
hosts, each one having less work to do
2. Running locally, the script will spin off each validation check as
its own process and they will all return more quickly.

This is necessary to add `firefox-ios` as a top repository since it has
657 swift files, which would otherwise take 5 minutes on CI, and I'm not
ready to wait that long.

Fixes #49
