### PR TITLE
Allow generic type params in member expressions

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -658,3 +658,22 @@ checkThat(dict is Dictionary<Foo, Bar>)
                   (type_identifier))
                 (user_type
                   (type_identifier))))))))))
+
+===
+Navigation expression involving explicit type parameters
+===
+
+SignalProducer<(), CarthageError>.empty
+
+---
+
+(source_file
+  (navigation_expression
+    (user_type
+      (type_identifier)
+      (type_arguments
+        (tuple_type)
+        (user_type
+          (type_identifier))))
+    (navigation_suffix
+      (simple_identifier))))

--- a/grammar.js
+++ b/grammar.js
@@ -402,7 +402,16 @@ module.exports = grammar({
       prec.left(PREC.POSTFIX, seq($._expression, $.indexing_suffix)),
 
     navigation_expression: ($) =>
-      prec.left(PREC.NAVIGATION, seq($._expression, $.navigation_suffix)),
+      prec.left(
+        PREC.NAVIGATION,
+        seq(
+          choice($._navigable_type_expression, $._expression),
+          $.navigation_suffix
+        )
+      ),
+
+    _navigable_type_expression: ($) =>
+      choice($.user_type, $.array_type, $.dictionary_type),
 
     // XXX precedence for ranges isn't right
     open_start_range_expression: ($) =>

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,8 +1,3 @@
-Carthage/Source/carthage/Extensions.swift
-Carthage/Source/carthage/Build.swift
-Carthage/Source/CarthageKit/Archive.swift
-Carthage/Source/CarthageKit/Project.swift
-Carthage/Source/CarthageKit/Git.swift
 Carthage/Tests/CarthageKitTests/CartfileCommentsSpec.swift
 firefox-ios/Shared/Functions.swift
 firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift


### PR DESCRIPTION
It is definitely legal (and has always been valid) to do something like:

```
SomeType.someMember
```

This has a type on the left-hand side and a member access on the
right-hand side. This grammar so far has been OK with that simple case,
because all it knows is that there's an identifier on the left. However,
this breaks down when we do the equally legal:

```
SomeGenericType<TypeParam>.someMember
```

because now this is _not_ an identifier on the left. To fix this, we
allow a few specific forms of a `_type` in a navigation expression. The
allowed types are exactly the ones that do not cause parsing
ambiguities, because that handles the cases that seem to exist in real
life.
