### PR TITLE
Fixing newlines and comments for if/else and do/catch

### DIFF
--- a/corpus/comments.txt
+++ b/corpus/comments.txt
@@ -80,4 +80,3 @@ Almost nested comments
     (multiline_comment)
     (multiline_comment)
     (multiline_comment))
-

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -449,6 +449,32 @@ else if let cPrime = c {
             (value_binding_pattern (non_binding_pattern (simple_identifier)))
             (simple_identifier))))
 
+===
+Else interacts with comments
+===
+
+if foo {
+  fooVal = 0; // A comment
+}
+// Another comment
+else if bar {
+}
+
+---
+
+(source_file
+  (if_statement
+    (simple_identifier)
+    (statements
+      (assignment
+        (directly_assignable_expression
+          (simple_identifier))
+        (integer_literal)))
+    (comment)
+    (comment)
+    (if_statement
+      (simple_identifier))))
+
 ==================
 Guard statements
 ==================

--- a/grammar.js
+++ b/grammar.js
@@ -147,6 +147,7 @@ module.exports = grammar({
     $.default_keyword,
     $._where_keyword,
     $._else,
+    $._catch,
   ],
 
   rules: {
@@ -768,7 +769,7 @@ module.exports = grammar({
 
     catch_block: ($) =>
       seq(
-        "catch",
+        $._catch,
         optional(generate_pattern_matching_rule($, true, false)),
         optional($.where_clause),
         $._block

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,4 +1,3 @@
 Carthage/Tests/CarthageKitTests/CartfileCommentsSpec.swift
 firefox-ios/Shared/Functions.swift
-firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift
 firefox-ios/Client/Frontend/Browser/Authenticator.swift

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,3 +1,2 @@
 Carthage/Tests/CarthageKitTests/CartfileCommentsSpec.swift
 firefox-ios/Shared/Functions.swift
-firefox-ios/Client/Frontend/Browser/Authenticator.swift


### PR DESCRIPTION
Fixes #47

Adds `catch` to the semi suppressor, and also suppresses semis at the
start of a comment. This also required a bit of rework that's been
overdue for a while, to not suppress _explicit_ semicolons - those don't
get used much, but there was one test case where one of those was
followed by a comment.
