### PR TITLE
Add fixes for `RxSwift`, and then add that as a top repository

### DIFF
--- a/.github/workflows/top-repos.yml
+++ b/.github/workflows/top-repos.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        repo: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        repo: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
 
     steps:
     - uses: actions/checkout@v2

--- a/grammar.js
+++ b/grammar.js
@@ -97,6 +97,10 @@ module.exports = grammar({
     // Custom operators get weird special handling for `<` characters in silly stuff like `func =<<<<T>(...)`
     [$.custom_operator],
     [$._prefix_unary_operator, $._referenceable_operator],
+
+    // `+(...)` is ambigously either "call the function produced by a reference to the operator `+`" or "use the unary
+    // operator `+` on the result of the parenthetical expression."
+    [$._additive_operator, $._prefix_unary_operator],
   ],
 
   extras: ($) => [
@@ -174,7 +178,7 @@ module.exports = grammar({
     simple_identifier: ($) =>
       choice(
         LEXICAL_IDENTIFIER,
-        token(seq("`", LEXICAL_IDENTIFIER, "`")),
+        /`[^\r\n` ]*`/,
         /\$[0-9]+/,
         token(seq("$", LEXICAL_IDENTIFIER))
       ),
@@ -1247,7 +1251,6 @@ module.exports = grammar({
         choice(
           $.simple_identifier,
           $._referenceable_operator,
-          $._additive_operator,
           $._bitwise_binary_operator
         )
       ),
@@ -1256,6 +1259,7 @@ module.exports = grammar({
       choice(
         $.custom_operator,
         $._comparison_operator,
+        $._additive_operator,
         $._multiplicative_operator,
         $._equality_operator,
         $._comparison_operator

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,2 +1,4 @@
 Carthage/Tests/CarthageKitTests/CartfileCommentsSpec.swift
 firefox-ios/Shared/Functions.swift
+RxSwift/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositories.swift
+RxSwift/Rx.playground/Pages/Transforming_Operators.xcplaygroundpage/Contents.swift

--- a/script-data/top-repositories.txt
+++ b/script-data/top-repositories.txt
@@ -2,6 +2,15 @@ Alamofire Alamofire/Alamofire 5.4.4
 lottie-ios airbnb/lottie-ios 3.2.3
 vapor vapor/vapor 3.3.3
 SwiftyJSON SwiftyJSON/SwiftyJSON 5.0.1
+RxSwift ReactiveX/RxSwift 6.2.0 0 9
+RxSwift ReactiveX/RxSwift 6.2.0 1 9
+RxSwift ReactiveX/RxSwift 6.2.0 2 9
+RxSwift ReactiveX/RxSwift 6.2.0 3 9
+RxSwift ReactiveX/RxSwift 6.2.0 4 9
+RxSwift ReactiveX/RxSwift 6.2.0 5 9
+RxSwift ReactiveX/RxSwift 6.2.0 6 9
+RxSwift ReactiveX/RxSwift 6.2.0 7 9
+RxSwift ReactiveX/RxSwift 6.2.0 8 9
 Kingfisher onevcat/Kingfisher 7.1.1
 shadowsocks shadowsocks/ShadowsocksX-NG v1.9.4
 Carthage Carthage/Carthage 0.38.0


### PR DESCRIPTION
Most of the parse failures in RxSwift can be fixed with two trivial
changes:
* Allowing `+` to be an operator reference (should have done already,
but was afraid of adding it as a conflict)
* Loosening validation on `...` identifiers

With these, we get a 99.8% parse rate on that repo, so it would be
a shame _not_ to add it to `top-repos`. The two remaining failures are
more insidious - one for emoji identifiers, the other involving binding
in nested tuple patterns. Both will be handled as their own bugs.
