### PR TITLE
Miscellaneous fixes for minor rare compile failures

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -345,7 +345,7 @@ class SomethingElse: ThingProvider {
                 (type_annotation (user_type (type_identifier)))
                 (computed_property
                     (statements
-                        (guard_expression
+                        (guard_statement
                             (value_binding_pattern (non_binding_pattern (simple_identifier)))
                             (simple_identifier)
                             (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -679,23 +679,35 @@ SignalProducer<(), CarthageError>.empty
       (simple_identifier))))
 
 ===
-Division will suppress the syntactic significance of a newline
+Suppressing the syntactic significance of a newline
 ===
 
 let _ = (1 + 2)
     / 3
 
+let additionIsSane = (2 + 2)
+    == 4
+
 ---
 
-    (source_file
-      (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (wildcard_pattern)))
-        (multiplicative_expression
-          (tuple_expression
-            (additive_expression
-              (integer_literal)
-              (integer_literal)))
-          (integer_literal))))
-
+(source_file
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (wildcard_pattern)))
+    (multiplicative_expression
+      (tuple_expression
+        (additive_expression
+          (integer_literal)
+          (integer_literal)))
+      (integer_literal)))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (equality_expression
+      (tuple_expression
+        (additive_expression
+          (integer_literal)
+          (integer_literal)))
+        (integer_literal))))

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -477,6 +477,27 @@ test { (a: Any?) in foo(a) }
                             (value_arguments (value_argument (simple_identifier))))))))))
 
 ===============
+Higher-order functions - pt 11
+===============
+
+types.flatMap { [abc, 1] }
+
+---
+
+    (source_file
+      (call_expression
+        (navigation_expression
+          (simple_identifier)
+          (navigation_suffix
+            (simple_identifier)))
+        (call_suffix
+          (lambda_literal
+            (statements
+              (array_literal
+                (simple_identifier)
+                (integer_literal)))))))
+
+===============
 Function type with wildcard
 ===============
 

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -620,3 +620,27 @@ public init() {
               (type_identifier)))
           (simple_identifier)
           (function_body))))))
+
+===
+Compiler diagnostics
+===
+
+#if SOME_FLAG
+#error("SOME_FLAG must not be enabled!")
+#elseif OTHER_FLAG
+#warning("OTHER_FLAG is deprecated!")
+#else
+#sourceLocation(file: "SomeFile.swift", line: 99)
+#endif
+
+---
+
+(source_file
+  (directive)
+  (diagnostic)
+  (directive)
+  (diagnostic)
+  (directive)
+  (directive)
+  (directive))
+

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -203,6 +203,8 @@ switch something {
 switch self {
 case .notExecutable(let path?):
     return "File not executable: \(path)"
+case let .isExecutable(path?):
+    return "File is executable: \(path)"
 }
 
 ---
@@ -230,6 +232,10 @@ case .notExecutable(let path?):
             (switch_pattern
                     (simple_identifier)
                     (non_binding_pattern (simple_identifier)))
+            (statements (control_transfer_statement (line_string_literal (interpolated_expression (simple_identifier))))))
+        (switch_entry
+            (switch_pattern
+                (non_binding_pattern (simple_identifier) (simple_identifier)))
             (statements (control_transfer_statement (line_string_literal (interpolated_expression (simple_identifier))))))))
 
 ==================

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -495,19 +495,19 @@ guard case justIdentifier = bound else { }
 ---
 
 (source_file
-    (guard_expression
+    (guard_statement
         (value_binding_pattern (non_binding_pattern (simple_identifier)))
         (call_expression (simple_identifier) (call_suffix (value_arguments)))
         (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
-    (guard_expression
+    (guard_statement
         (call_expression (simple_identifier) (call_suffix (value_arguments)))
         (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
-    (guard_expression
+    (guard_statement
         (binding_pattern
             (simple_identifier) (simple_identifier)
             (non_binding_pattern (simple_identifier)))
         (call_expression (simple_identifier) (call_suffix (value_arguments))))
-    (guard_expression (binding_pattern (simple_identifier)) (simple_identifier)))
+    (guard_statement (binding_pattern (simple_identifier)) (simple_identifier)))
 ==================
 Compound guard
 ==================
@@ -519,7 +519,7 @@ guard let something = doThing(), something.isSpecial() else {
 ---
 
 (source_file
-    (guard_expression
+    (guard_statement
         (value_binding_pattern (non_binding_pattern (simple_identifier)))
         (call_expression (simple_identifier) (call_suffix (value_arguments)))
         (call_expression

--- a/grammar.js
+++ b/grammar.js
@@ -32,7 +32,6 @@ const PREC = {
   PREFIX: 7,
   COMPARISON: 6,
   POSTFIX: 6,
-  CAPTURE_LIST_ITEM: 6,
   EQUALITY: 5,
   CONJUNCTION: 4,
   DISJUNCTION: 3,
@@ -101,6 +100,11 @@ module.exports = grammar({
     // `+(...)` is ambigously either "call the function produced by a reference to the operator `+`" or "use the unary
     // operator `+` on the result of the parenthetical expression."
     [$._additive_operator, $._prefix_unary_operator],
+
+    // `{ [self, b, c] ...` could be a capture list or an array literal depending on what else happens.
+    [$._capture_list_item, $.self_expression],
+    [$._capture_list_item, $._expression],
+    [$._capture_list_item, $._expression, $._simple_user_type],
   ],
 
   extras: ($) => [
@@ -673,15 +677,12 @@ module.exports = grammar({
     capture_list: ($) => seq("[", sep1($._capture_list_item, ","), "]"),
 
     _capture_list_item: ($) =>
-      prec(
-        PREC.CAPTURE_LIST_ITEM,
-        choice(
-          "self",
-          seq(
-            optional($.ownership_modifier),
-            $.simple_identifier,
-            optional(seq($._equal_sign, $._expression))
-          )
+      choice(
+        "self",
+        seq(
+          optional($.ownership_modifier),
+          $.simple_identifier,
+          optional(seq($._equal_sign, $._expression))
         )
       ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -111,6 +111,7 @@ module.exports = grammar({
     $.comment,
     $.multiline_comment,
     $.directive,
+    $.diagnostic,
     /\s+/, // Whitespace
   ],
 
@@ -1569,7 +1570,21 @@ module.exports = grammar({
             seq("#if", /.*/),
             seq("#elseif", /.*/),
             seq("#else", /.*/),
-            seq("#endif", /.*/)
+            seq("#endif", /.*/),
+            seq(/#sourceLocation([^\r\n]*)/)
+          )
+        )
+      ),
+
+    diagnostic: ($) =>
+      token(
+        prec(
+          PREC.COMMENT,
+          choice(
+            // Using regexes here, rather than actually validating the string literal, because complex string literals
+            // cannot be used inside `token()` and we need that to ensure we get the right precedence.
+            seq(/#error([^\r\n]*)/),
+            seq(/#warning([^\r\n]*)/)
           )
         )
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -610,7 +610,6 @@ module.exports = grammar({
         $.dictionary_literal,
         $.self_expression,
         $.super_expression,
-        $.guard_expression,
         $.try_expression,
         $._referenceable_operator,
         $.key_path_expression,
@@ -742,7 +741,7 @@ module.exports = grammar({
         seq($._direct_or_indirect_binding, $._equal_sign, $._expression)
       ),
 
-    guard_expression: ($) =>
+    guard_statement: ($) =>
       prec.right(
         seq(
           "guard",
@@ -905,6 +904,7 @@ module.exports = grammar({
           $.repeat_while_statement,
           $.do_statement,
           $.if_statement,
+          $.guard_statement,
           $.switch_statement
         )
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -1665,8 +1665,7 @@ function generate_pattern_matching_rule(
     ? [
         seq(
           binding_pattern_prefix,
-          generate_pattern_matching_rule($, false, false, false),
-          optional($._quest)
+          generate_pattern_matching_rule($, false, false, false)
         ),
       ]
     : [];
@@ -1684,5 +1683,5 @@ function generate_pattern_matching_rule(
     .concat(case_pattern)
     .concat(expression_pattern);
 
-  return choice(...all_patterns);
+  return seq(choice(...all_patterns), optional($._quest));
 }

--- a/grammar.js
+++ b/grammar.js
@@ -151,12 +151,15 @@ module.exports = grammar({
     $._disjunction_operator,
     $._nil_coalescing_operator,
     $._equal_sign,
+    $._eq_eq,
     $._throws_keyword,
     $._rethrows_keyword,
     $.default_keyword,
     $._where_keyword,
     $._else,
     $._catch,
+    $._as_quest,
+    $._as_bang,
   ],
 
   rules: {
@@ -825,7 +828,7 @@ module.exports = grammar({
 
     _assignment_and_operator: ($) => choice("+=", "-=", "*=", "/=", "%=", "="),
 
-    _equality_operator: ($) => choice("!=", "!==", "==", "==="),
+    _equality_operator: ($) => choice("!=", "!==", $._eq_eq, "==="),
 
     _comparison_operator: ($) => choice("<", ">", "<=", ">="),
 
@@ -835,7 +838,7 @@ module.exports = grammar({
 
     _multiplicative_operator: ($) => choice("*", "/", "%"),
 
-    _as_operator: ($) => choice("as", "as?", "as!"),
+    _as_operator: ($) => choice("as", $._as_quest, $._as_bang),
 
     _prefix_unary_operator: ($) =>
       prec.right(
@@ -1219,7 +1222,12 @@ module.exports = grammar({
       ),
 
     equality_constraint: ($) =>
-      seq(repeat($.attribute), $.identifier, choice("=", "=="), $._type),
+      seq(
+        repeat($.attribute),
+        $.identifier,
+        choice($._equal_sign, $._eq_eq),
+        $._type
+      ),
 
     _class_member_declarations: ($) =>
       repeat1(seq($._type_level_declaration, $._semi)),
@@ -1445,7 +1453,7 @@ module.exports = grammar({
                 ":",
                 "*",
                 ",",
-                "=="
+                $._eq_eq
               )
             ),
             ")"

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -15,15 +15,18 @@ enum TokenType {
     DISJUNCTION_OPERATOR,
     NIL_COALESCING_OPERATOR,
     EQUAL_SIGN,
+    EQ_EQ,
     THROWS_KEYWORD,
     RETHROWS_KEYWORD,
     DEFAULT_KEYWORD,
     WHERE_KEYWORD,
     ELSE_KEYWORD,
-    CATCH_KEYWORD
+    CATCH_KEYWORD,
+    AS_QUEST,
+    AS_BANG
 };
 
-#define CROSS_SEMI_OPERATOR_COUNT 14
+#define CROSS_SEMI_OPERATOR_COUNT 18
 
 const char* CROSS_SEMI_OPERATORS[CROSS_SEMI_OPERATOR_COUNT] = {
     "->",
@@ -34,12 +37,15 @@ const char* CROSS_SEMI_OPERATORS[CROSS_SEMI_OPERATOR_COUNT] = {
     "||",
     "??",
     "=",
+    "==",
     "throws",
     "rethrows",
     "default",
     "where",
     "else",
-    "catch"
+    "catch",
+    "as?",
+    "as!"
 };
 
 const enum TokenType CROSS_SEMI_SYMBOLS[CROSS_SEMI_OPERATOR_COUNT] = {
@@ -51,16 +57,19 @@ const enum TokenType CROSS_SEMI_SYMBOLS[CROSS_SEMI_OPERATOR_COUNT] = {
     DISJUNCTION_OPERATOR,
     NIL_COALESCING_OPERATOR,
     EQUAL_SIGN,
+    EQ_EQ,
     THROWS_KEYWORD,
     RETHROWS_KEYWORD,
     DEFAULT_KEYWORD,
     WHERE_KEYWORD,
     ELSE_KEYWORD,
-    CATCH_KEYWORD
+    CATCH_KEYWORD,
+    AS_QUEST,
+    AS_BANG
 };
 
 #define NON_CONSUMING_CROSS_SEMI_CHAR_COUNT 3
-const char NON_CONSUMING_CROSS_SEMI_CHARS[CROSS_SEMI_OPERATOR_COUNT] = { '?', ':', '{', '}' };
+const char NON_CONSUMING_CROSS_SEMI_CHARS[CROSS_SEMI_OPERATOR_COUNT] = { '?', ':', '{' };
 
 /**
  * All possible results of having performed some sort of parsing.


### PR DESCRIPTION
- Create conflict for capture list items
- Guard statements are not expressions
- Support more compiler control statements
- Support optionals in patterns that have already been bound
- Add some more characters to the semi suppressor
