### PR TITLE
Allow expressions in annotation attributes

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -108,6 +108,9 @@ Class with annotations
 class Test : Protocol {
     @objc(someArgument:)
     dynamic func someFunction(with argument: Int) { }
+
+    @DocumentationAnnotation(help: "Calls this function nicely.")
+    func someFunction(nice argument: Int) { }
 }
 
 ---
@@ -127,6 +130,16 @@ class Test : Protocol {
                         (user_type (type_identifier))
                         (simple_identifier))
                     (property_modifier))
+                    (simple_identifier)
+                    (external_parameter_name)
+                    (parameter (simple_identifier) (user_type (type_identifier)))
+                    (function_body))
+            (function_declaration
+                (modifiers
+                    (attribute
+                        (user_type (type_identifier))
+                        (simple_identifier)
+                        (line_string_literal)))
                     (simple_identifier)
                     (external_parameter_name)
                     (parameter (simple_identifier) (user_type (type_identifier)))
@@ -764,10 +777,15 @@ public extension Foo where T == (arg1: Arg1, arg2: Arg2) { }
 Deprecation
 ============
 class Computer<T> {
-    @available(*, deprecated, message: "See replacement: computeV2`")
+    @available(*, deprecated, message: "See replacement: computeV2")
     func compute() { }
-    @available(*, deprecated, message: "See replacement: computeV2`")
+
+    @available(*, deprecated, message: "See replacement: computeV2")
     var computeResult: T!
+
+    @available(swift 3.0.2)
+    @available(iOS 10.0, macOS 10.12, *)
+    func computeV2() { }
 }
 
 enum ComputeType {
@@ -798,7 +816,19 @@ enum ComputeType {
                     (simple_identifier)
                     (line_string_literal)))
                 (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation (user_type (type_identifier))))))
+                (type_annotation (user_type (type_identifier))))
+            (function_declaration
+                (modifiers
+                    (attribute
+                        (user_type (type_identifier))
+                        (simple_identifier)
+                        (integer_literal) (integer_literal) (integer_literal))
+                    (attribute
+                        (user_type (type_identifier))
+                        (simple_identifier) (integer_literal) (integer_literal)
+                        (simple_identifier) (integer_literal) (integer_literal)))
+                (simple_identifier)
+                (function_body))))
     (class_declaration
         (type_identifier)
         (enum_class_body

--- a/grammar.js
+++ b/grammar.js
@@ -1444,17 +1444,18 @@ module.exports = grammar({
         optional(
           seq(
             "(",
-            repeat(
+            sep1(
               choice(
-                $.simple_identifier,
-                $.type_arguments,
-                $._basic_literal,
-                $.key_path_expression,
-                ":",
-                "*",
-                ",",
-                $._eq_eq
-              )
+                // labeled function parameters, used in custom property wrappers
+                seq($.simple_identifier, ":", $._expression),
+                // Unlabeled function parameters, simple identifiers, or `*`
+                $._expression,
+                // References to param names (used in `@objc(foo:bar:)`)
+                repeat1(seq($.simple_identifier, ":")),
+                // Version restrictions (iOS 3.4.5, Swift 5.0.0)
+                seq(repeat1($.simple_identifier), sep1($.integer_literal, "."))
+              ),
+              ","
             ),
             ")"
           )


### PR DESCRIPTION
The ArgumentParser library makes heavy use of custom attributes (are
they even called attributes here?). The grammar needs to respect those
rather than treating them as some sort of malformed `@available(...)`
attribute.

This change gives us a bit more structure to what we expect to see in an
attribute, whether built-in or custom.
