### PR TITLE
Fix pattern matching edge cases

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -533,6 +533,31 @@ guard let something = doThing(), something.isSpecial() else {
             (call_suffix (value_arguments)))
         (statements (call_expression (simple_identifier) (call_suffix (value_arguments))))))
 
+===
+Type annotation on `guard case let`
+===
+
+guard case let size: Int = variable.size else {
+    return nil
+}
+
+---
+
+(source_file
+  (guard_statement
+    (binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (type_annotation
+      (user_type
+        (type_identifier)))
+    (navigation_expression
+      (simple_identifier)
+      (navigation_suffix
+        (simple_identifier)))
+    (statements
+      (control_transfer_statement))))
+
 ================
 Availability conditions
 ================

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -54,7 +54,7 @@ for case .some(value) in valuesMaybe { }
 for case .some((.some(0), .some(1))) in crazyValues {
 }
 
-for value in values where value.isExcellent() {
+for var value in values where value.isExcellent() {
 }
 
 ---
@@ -82,7 +82,7 @@ for value in values where value.isExcellent() {
         (integer_literal)
         (simple_identifier))
     (for_statement
-        (simple_identifier)
+        (non_binding_pattern (simple_identifier))
         (simple_identifier)
         (where_clause
             (call_expression

--- a/grammar.js
+++ b/grammar.js
@@ -1641,11 +1641,11 @@ function generate_type_casting_pattern($, allows_binding) {
 function generate_pattern_matching_rule(
   $,
   allows_binding,
-  requires_case_keyword,
+  allows_case_keyword,
   allows_expressions,
   force
 ) {
-  if (!force && !requires_case_keyword) {
+  if (!force && !allows_case_keyword) {
     if (allows_binding && !allows_expressions) {
       return $.binding_pattern;
     }
@@ -1669,8 +1669,8 @@ function generate_pattern_matching_rule(
     generate_type_casting_pattern($, allows_binding),
   ];
 
-  const binding_pattern_prefix = requires_case_keyword
-    ? choice(seq("case", "var"), seq("case", "let"))
+  const binding_pattern_prefix = allows_case_keyword
+    ? seq(optional("case"), choice("var", "let"))
     : choice("var", "let");
 
   const binding_pattern_if_allowed = allows_binding
@@ -1682,7 +1682,7 @@ function generate_pattern_matching_rule(
       ]
     : [];
 
-  const case_pattern = requires_case_keyword
+  const case_pattern = allows_case_keyword
     ? seq("case", generate_case_pattern($, allows_binding))
     : generate_case_pattern($, allows_binding);
 

--- a/grammar.js
+++ b/grammar.js
@@ -1482,9 +1482,12 @@ module.exports = grammar({
       prec.left(2, generate_pattern_matching_rule($, false, false, true, true)),
 
     _direct_or_indirect_binding: ($) =>
-      choice(
-        seq($.value_binding_pattern, optional($.type_annotation)),
-        seq("case", generate_pattern_matching_rule($, true, false, false))
+      seq(
+        choice(
+          $.value_binding_pattern,
+          seq("case", generate_pattern_matching_rule($, true, false, false))
+        ),
+        optional($.type_annotation)
       ),
 
     wildcard_pattern: ($) => "_",


### PR DESCRIPTION
- Allow type annotations on if/guard case conditions
- Allow `for var` without `case`
