### PR TITLE
Disallow different characters after certain operators

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -682,11 +682,15 @@ SignalProducer<(), CarthageError>.empty
 Suppressing the syntactic significance of a newline
 ===
 
-let _ = (1 + 2)
+let _ = (1+2)
     / 3
 
 let additionIsSane = (2 + 2)
     == 4
+
+let two = 2
+    + 2
+    - 2
 
 ---
 
@@ -710,4 +714,13 @@ let additionIsSane = (2 + 2)
         (additive_expression
           (integer_literal)
           (integer_literal)))
+          (integer_literal)))
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (additive_expression
+          (additive_expression
+            (integer_literal)
+            (integer_literal))
         (integer_literal))))

--- a/grammar.js
+++ b/grammar.js
@@ -152,12 +152,15 @@ module.exports = grammar({
     $._nil_coalescing_operator,
     $._equal_sign,
     $._eq_eq,
+    $._plus_then_ws, // + symbol with whitespace after it
+    $._minus_then_ws, // - symbol with whitespace after it
     $._throws_keyword,
     $._rethrows_keyword,
     $.default_keyword,
     $._where_keyword,
     $._else,
     $._catch,
+    $._as,
     $._as_quest,
     $._as_bang,
   ],
@@ -834,11 +837,12 @@ module.exports = grammar({
 
     _is_operator: ($) => "is",
 
-    _additive_operator: ($) => choice("+", "-"),
+    _additive_operator: ($) =>
+      choice($._plus_then_ws, $._minus_then_ws, "+", "-"),
 
     _multiplicative_operator: ($) => choice("*", "/", "%"),
 
-    _as_operator: ($) => choice("as", $._as_quest, $._as_bang),
+    _as_operator: ($) => choice($._as, $._as_quest, $._as_bang),
 
     _prefix_unary_operator: ($) =>
       prec.right(
@@ -1634,7 +1638,11 @@ function generate_case_pattern($, allows_binding, force) {
 function generate_type_casting_pattern($, allows_binding) {
   return choice(
     seq("is", $._type),
-    seq(generate_pattern_matching_rule($, allows_binding, false), "as", $._type)
+    seq(
+      generate_pattern_matching_rule($, allows_binding, false),
+      $._as,
+      $._type
+    )
   );
 }
 

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -2,5 +2,3 @@ firefox-ios/Shared/Functions.swift
 RxSwift/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositories.swift
 RxSwift/Rx.playground/Pages/Transforming_Operators.xcplaygroundpage/Contents.swift
 SwiftLint/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
-SwiftLint/Source/SwiftLintFramework/Rules/Metrics/NestingRuleExamples.swift
-SwiftLint/Source/SwiftLintFramework/Rules/Style/StatementPositionRule.swift

--- a/scripts/top-repos.sh
+++ b/scripts/top-repos.sh
@@ -99,10 +99,16 @@ while read line ; do
     cd $tmpdir
     checkout $line
     cd $parser_dir
-    validate $line &
-    pids+=($!)
+    if [ -z "$1" ]; then
+        validate $line &
+        pids+=($!)
+    else
+        validate $line
+    fi
 done <<<"$repos"
 
-for pid in "${pids[@]}" ; do
-    wait $pid
-done
+if [ -z "$1" ]; then
+    for pid in "${pids[@]}" ; do
+        wait $pid
+    done
+fi


### PR DESCRIPTION
Not all the operators in `scanner.c` are the same. In some cases, the
operators should be ignored if the character after them potentially lets
them be a custom operator themselves. In other cases, the operator
should be ignored if it's followed by alphanumeric characters (since
that would make it an identifier).

We solve this by adding a new list for the "illegal terminators" and
checking against those. This has the bonus of letting us add two new
semi suppressors:
1. `as`, the bare keyword, now that we aren't fooled by having it at the
start of a word
2. `+` and `-`, but only when followed by whitespace - when there's no
whitespace between the operator and the subsequent token, but there _is_
whitespace before it, Swift treats it as a prefix operator. We just have
to check the trailing whitespace here because we're just concerned about
semi suppression.
