### PR TITLE
Add support for recursive enums

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1181,6 +1181,7 @@ module.exports = grammar({
             $.class_body
           ),
           seq(
+            optional("indirect"),
             "enum",
             alias($.simple_identifier, $.type_identifier),
             optional($.type_parameters),
@@ -1288,6 +1289,7 @@ module.exports = grammar({
       prec.left(
         seq(
           optional($.modifiers),
+          optional("indirect"),
           "case",
           sep1(
             seq(


### PR DESCRIPTION
The keyword `indirect` is legal on an enum class declaration or on an
individual case, and tells the compiler to use the heap to avoid an
infinitely sized structure. Add the keyword directly into those places
where it is legal.
