### PR TITLE
Where clauses go on switch patterns, not cases

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -206,7 +206,7 @@ Weird switch statements
 
 switch something {
     case let .pattern2(_, bound): fallthrough
-    case .ident where someCondition: fallthrough
+    case .ident where someCondition, ident2: fallthrough
     @unknown default: return "Goodbye"
 }
 
@@ -231,6 +231,7 @@ case let .isExecutable(path?):
         (switch_entry
             (switch_pattern (simple_identifier))
             (simple_identifier)
+            (switch_pattern (simple_identifier))
             (statements (simple_identifier)))
         (switch_entry
             (modifiers (attribute (user_type (type_identifier))))

--- a/grammar.js
+++ b/grammar.js
@@ -765,10 +765,16 @@ module.exports = grammar({
       seq(
         optional($.modifiers),
         choice(
-          seq("case", $.switch_pattern, repeat(seq(",", $.switch_pattern))),
+          seq(
+            "case",
+            seq(
+              $.switch_pattern,
+              optional(seq($._where_keyword, $._expression))
+            ),
+            repeat(seq(",", $.switch_pattern))
+          ),
           $.default_keyword
         ),
-        optional(seq($._where_keyword, $._expression)),
         ":",
         $.statements,
         optional("fallthrough")


### PR DESCRIPTION
The grammar erroneously had it that a switch _case_ would get a single
`where` clause, disallowing something like:

```
case .foo(x) where x.count() == 0, .bar(x):
```

Allowing `where`-clauses per pattern is strictly more flexible.
