### PR TITLE
Run corpus tests using memcheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "install": "tree-sitter generate",
     "ci": "prettier --check grammar.js",
-    "test": "tree-sitter test",
-    "top-repos": "./scripts/top-repos.sh"
+    "test": "./scripts/test-with-memcheck.sh --install-valgrind"
   },
   "repository": {
     "type": "git",

--- a/scripts/test-with-memcheck.sh
+++ b/scripts/test-with-memcheck.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$1" == "--install-valgrind" ]]; then
+    sudo apt install -y valgrind
+    shift
+fi
+
+valgrind tree-sitter test


### PR DESCRIPTION
Corpus tests run very quickly and we don't care about their output (just
about the return code). This makes them a great candidate for running
under `valgrind`.
