### PR TITLE
Overhaul precedences

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -105,6 +105,46 @@ someVeryLongFunctionCall()
             (simple_identifier)
             (call_suffix (value_arguments)))
         (simple_identifier)))
+===
+Ternary within another expression
+===
+
+if a ? b : c == d {
+}
+
+---
+
+(source_file
+  (if_statement
+    (ternary_expression
+      (simple_identifier)
+      (simple_identifier)
+      (equality_expression
+        (simple_identifier)
+        (simple_identifier)))))
+
+===
+Ternary with a function at the end
+===
+
+foo() ? bar() : baz()
+
+---
+
+(source_file
+  (ternary_expression
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))))
 
 ==================
 Multiple expressions on one line using semicolons
@@ -409,14 +449,10 @@ let result: MyEnumType = condition ? .someEnumCase : .someOtherEnum
             (prefix_expression (simple_identifier)))))
 
 ======
-Range expression
+Range expression in indexing
 ======
 
 string[..<string.index(before: string.endIndex)]
-
-for i in 0 ..< something.count {
-    // Do something
-}
 
 ---
 
@@ -426,13 +462,26 @@ for i in 0 ..< something.count {
         (call_suffix
             (value_arguments
                 (value_argument
-                    (call_expression
-                        (open_start_range_expression (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier))))
-                        (call_suffix
-                            (value_arguments
-                                (value_argument
-                                    (simple_identifier)
-                                    (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))))))))))
+                    (open_start_range_expression
+                        (call_expression
+                            (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
+                            (call_suffix
+                                (value_arguments
+                                    (value_argument
+                                        (simple_identifier)
+                                        (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))))))))))))
+
+======
+Range expression in loop
+======
+
+for i in 0 ..< something.count {
+    // Do something
+}
+
+---
+
+(source_file
     (for_statement
         (simple_identifier)
         (range_expression
@@ -724,3 +773,33 @@ let two = 2
             (integer_literal)
             (integer_literal))
         (integer_literal))))
+
+===
+Simple try
+===
+
+try foo()
+
+---
+
+(source_file
+  (try_expression
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))))
+
+===
+Try and ternary
+===
+
+try foo() ? 1 : 0
+
+---
+
+(source_file
+  (try_expression
+    (ternary_expression
+      (call_expression (simple_identifier) (call_suffix (value_arguments)))
+      (integer_literal)
+      (integer_literal))))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -377,7 +377,7 @@ func doSomething() {
     if let a = try? Foo.getValue("key") {
         return a
     }
-    return default
+    return defaultValue
 }
 
 ---
@@ -391,16 +391,16 @@ func doSomething() {
               (value_binding_pattern
                 (non_binding_pattern
                   (simple_identifier)))
-              (call_expression
-                (try_expression
+              (try_expression
+                (call_expression
                   (navigation_expression
                     (simple_identifier)
                     (navigation_suffix
-                      (simple_identifier))))
-                (call_suffix
-                  (value_arguments
-                    (value_argument
-                      (line_string_literal)))))
+                      (simple_identifier)))
+                  (call_suffix
+                     (value_arguments
+                       (value_argument
+                         (line_string_literal))))))
               (statements
                 (control_transfer_statement
                   (simple_identifier))))


### PR DESCRIPTION
There are a few bugs with things that don't quite have the right
precedence, like ranges and `try`. This commit reworks all of those to
return what appear to be the correct results.

This also reorganizes precedences to be a bit more friendly and, rather
than dealing in integer values, just dealing in relative positions.
Seeing at a glance that "try and ternary are both at the same position"
is more immediately useful than seeing that they are at position X.

Fixes #1
Fixes #3
