### PR TITLE
Fix inconsistent conflict resolution for `try` and ternary

### DIFF
--- a/grammar.ts
+++ b/grammar.ts
@@ -668,7 +668,11 @@ module.exports = grammar({
             prec.right(-2, $._expression),
             prec.left(0, $.call_expression),
             // Similarly special case the ternary expression, where `try` may come earlier than it is actually needed.
-            prec.left(-1, $.ternary_expression)
+            // When the parser just encounters some identifier after a `try`, it should prefer the `call_expression` (so
+            // this should be lower in priority than that), but when we encounter an ambiguous expression that might be
+            // either `try (foo() ? ...)` or `(try foo()) ? ...`, we should prefer the former. We accomplish that by
+            // giving it a _static precedence_ of -1 but a _dynamic precedence_ of 1.
+            prec.dynamic(1, prec.left(-1, $.ternary_expression))
           )
         )
       ),


### PR DESCRIPTION
In most places in the grammar, we rely on our conflicts resolving
themselves with only one parse interpretation being valid. With `try` and
ternary, that isn't the case: both of `try (foo() ? bar() : baz)` and
`(try foo()) ? bar() : baz` are valid. This matters because `bar()`
could also be a `throws` function, and our `try` is supposed to cover
it.

The rules for dynamic precedence are described here:
https://github.com/tree-sitter/tree-sitter/issues/678

Based on those, it seems like we were getting the correct parse result
in our test cases solely because of some rule definition order, which
"isn't really meant to be relied on." This exposes itself in some
unrelated changes for a custom string interpolation (not included in
this PR) where the rule order changes and flips our interpretation to
the wrong one.

Instead of relying on the ordering behavior, this change tells the
parser to choose `try (foo() ? ...)` over `(try foo()) ? ...` by giving
it a dynamic precedence value. This makes our ordering consistent even
in the face of later rule changes.
