### PR TITLE
Add support for custom interpolation syntax

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -64,6 +64,20 @@ Multiline
     (line_string_literal) (multi_line_string_literal) (comment))
 
 ==================
+Custom interpolation
+==================
+"Hi, I'm \(format: age)"
+
+---
+
+(source_file
+  (line_string_literal
+    (interpolated_expression
+      (simple_identifier)
+      (simple_identifier))))
+
+
+==================
 Strings with newline escaping
 ==================
 
@@ -233,11 +247,13 @@ extension URL {
                 (raw_str_part)
                 (raw_str_interpolation
                     (raw_str_interpolation_start)
-                    (simple_identifier))
+                    (interpolated_expression
+                        (simple_identifier)))
                 (raw_str_part)
                 (raw_str_interpolation
                     (raw_str_interpolation_start)
-                    (simple_identifier))
+                    (interpolated_expression
+                        (simple_identifier)))
                 (raw_str_end_part)))))))))
 
 ==================
@@ -262,7 +278,8 @@ let _ = ##"\##(a)\#(b)\##(c)\#(d)"# ##"##
             (raw_str_part)
             (raw_str_interpolation
                 (raw_str_interpolation_start)
-                (simple_identifier)
+                (interpolated_expression
+                    (simple_identifier))
                 (multiline_comment))
             (raw_str_end_part))))))
   (property_declaration
@@ -273,7 +290,8 @@ let _ = ##"\##(a)\#(b)\##(c)\#(d)"# ##"##
       (raw_str_part)
       (raw_str_interpolation
           (raw_str_interpolation_start)
-          (simple_identifier))
+          (interpolated_expression
+              (simple_identifier)))
       (raw_str_end_part)))
   (property_declaration
     (value_binding_pattern
@@ -289,11 +307,13 @@ let _ = ##"\##(a)\#(b)\##(c)\#(d)"# ##"##
       (raw_str_part)
       (raw_str_interpolation
           (raw_str_interpolation_start)
-          (simple_identifier))
+          (interpolated_expression
+              (simple_identifier)))
       (raw_str_part)
       (raw_str_interpolation
           (raw_str_interpolation_start)
-          (simple_identifier))
+          (interpolated_expression
+              (simple_identifier)))
       (raw_str_end_part))))
 
 ===

--- a/grammar.ts
+++ b/grammar.ts
@@ -317,15 +317,17 @@ module.exports = grammar({
       ),
 
     raw_str_interpolation: ($) =>
-      seq($.raw_str_interpolation_start, $._expression, ")"),
+      seq($.raw_str_interpolation_start, $._interpolation_contents, ")"),
 
     raw_str_interpolation_start: ($) => /\\#*\(/,
 
     _multi_line_string_content: ($) =>
       choice($._multi_line_str_text, $._escaped_identifier, '"'),
 
-    _interpolation: ($) =>
-      seq("\\(", alias($._expression, $.interpolated_expression), ")"),
+    _interpolation: ($) => seq("\\(", $._interpolation_contents, ")"),
+
+    _interpolation_contents: ($) =>
+      sep1(alias($.value_argument, $.interpolated_expression), ","),
 
     _escaped_identifier: ($) => /\\[0\\tnr"'\n]/,
 


### PR DESCRIPTION
Swift has a magical syntax for string interpolation that involves
special `appendInterpolation` functions and causes the interpolation to
look like a value argument.

This adds support for that.
