### PR TITLE
Add `async` / `await`

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -803,3 +803,79 @@ try foo() ? 1 : 0
       (call_expression (simple_identifier) (call_suffix (value_arguments)))
       (integer_literal)
       (integer_literal))))
+
+===
+Simple await
+===
+
+await foo()
+
+---
+
+(source_file
+  (await_expression
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))))
+
+===
+try await
+===
+
+try await foo()
+await try foo()
+
+---
+
+(source_file
+  (try_expression
+    (await_expression
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments)))))
+  (await_expression
+    (try_expression
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments))))))
+
+
+===
+Await and ternary
+===
+
+await foo() ? 1 : 0
+
+---
+
+(source_file
+  (await_expression
+    (ternary_expression
+      (call_expression (simple_identifier) (call_suffix (value_arguments)))
+      (integer_literal)
+      (integer_literal))))
+
+===
+for try await
+===
+
+for try await value in values {
+    print(value)
+}
+
+---
+
+(source_file
+  (for_statement
+    (simple_identifier)
+    (simple_identifier)
+    (statements
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments
+            (value_argument
+              (simple_identifier))))))))

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -307,6 +307,35 @@ func iCanDoBetter()
                 (control_transfer_statement (prefix_expression (integer_literal)))))))
 
 
+==================
+Async functions
+==================
+
+func eventually() async -> Int { return -1 }
+func maybe()
+    async
+    throws
+    -> Int { return -2 }
+
+---
+
+(source_file
+    (function_declaration
+        (simple_identifier)
+                (async_modifier)
+        (user_type (type_identifier))
+        (function_body
+            (statements
+                (control_transfer_statement (prefix_expression (integer_literal))))))
+    (function_declaration
+        (simple_identifier)
+        (async_modifier)
+        (throws_modifier)
+        (user_type (type_identifier))
+        (function_body
+            (statements
+                (control_transfer_statement (prefix_expression (integer_literal)))))))
+
 
 ==================
 Higher-order functions - pt 1

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -26,10 +26,11 @@ enum TokenType {
     CATCH_KEYWORD,
     AS_KEYWORD,
     AS_QUEST,
-    AS_BANG
+    AS_BANG,
+    ASYNC_KEYWORD
 };
 
-#define CROSS_SEMI_OPERATOR_COUNT 20
+#define CROSS_SEMI_OPERATOR_COUNT 21
 
 const char* CROSS_SEMI_OPERATORS[CROSS_SEMI_OPERATOR_COUNT] = {
     "->",
@@ -51,7 +52,8 @@ const char* CROSS_SEMI_OPERATORS[CROSS_SEMI_OPERATOR_COUNT] = {
     "catch",
     "as",
     "as?",
-    "as!"
+    "as!",
+    "async"
 };
 
 enum IllegalTerminatorGroup {
@@ -81,7 +83,8 @@ const enum IllegalTerminatorGroup CROSS_SEMI_ILLEGAL_TERMINATORS[CROSS_SEMI_OPER
     ALPHANUMERIC,     // catch
     ALPHANUMERIC,     // as
     OPERATOR_SYMBOLS, // as?
-    OPERATOR_SYMBOLS  // as!
+    OPERATOR_SYMBOLS, // as!
+    ALPHANUMERIC      // async
 };
 
 const enum TokenType CROSS_SEMI_SYMBOLS[CROSS_SEMI_OPERATOR_COUNT] = {
@@ -104,7 +107,8 @@ const enum TokenType CROSS_SEMI_SYMBOLS[CROSS_SEMI_OPERATOR_COUNT] = {
     CATCH_KEYWORD,
     AS_KEYWORD,
     AS_QUEST,
-    AS_BANG
+    AS_BANG,
+    ASYNC_KEYWORD
 };
 
 #define NON_CONSUMING_CROSS_SEMI_CHAR_COUNT 3


### PR DESCRIPTION
Allows async in function declarations and type signatures. `async` must
always come before `throws`. This keyword also has to go in the semi
suppressor for the same reason `throws` and `rethrows` are there.

Also allows `await` before any expression. Gives it the same special
behavior that `try` gets, where it has an affinity for function calls
and ternary operators, but can be placed before any expression.

Special cases the `for try await` syntax that Swift added for async
sequences. That doesn't appear to have made it into the grammar yet.
Usage makes it seem like it must be either `for await` or
`for try await`, not permiting just `for try` alone, but without an
official reference it seems best to simply allow `for try`.
