### PR TITLE
Support attributes in a few places where they should be legal

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -1048,3 +1048,24 @@ public var someVar: String {
         (getter_specifier)
         (statements
             (line_string_literal))))))
+
+===
+Annotations on inheritance
+===
+
+extension TrustMe: @unchecked Sendable { }
+
+---
+
+(source_file
+  (class_declaration
+    (identifier
+      (simple_identifier))
+    (attribute
+      (user_type
+        (type_identifier)))
+    (inheritance_specifier
+      (user_type
+        (type_identifier)))
+    (class_body)))
+

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -400,7 +400,7 @@ test { (a: inout Int) in }
 Higher-order functions - pt 6
 ==================
 
-test { [weak self, otherSelf] (a) in }
+test { @Special [weak self, otherSelf] (a) in }
 
 ---
 (source_file
@@ -408,7 +408,11 @@ test { [weak self, otherSelf] (a) in }
         (simple_identifier)
         (call_suffix
             (lambda_literal
-                (capture_list (ownership_modifier) (simple_identifier) (simple_identifier))
+                (capture_list
+                    (attribute (user_type (type_identifier)))
+                    (ownership_modifier)
+                    (simple_identifier)
+                    (simple_identifier))
                 (lambda_function_type (lambda_function_type_parameters (simple_identifier)))))))
 
 ==================

--- a/grammar.ts
+++ b/grammar.ts
@@ -151,6 +151,14 @@ module.exports = grammar({
       $.computed_modify,
       $.computed_setter,
     ],
+    // In a lambda literal's capture list, same problem with class attributes vs capture specifier attributes.
+    [
+      $.capture_list,
+      $._local_property_declaration,
+      $._local_typealias_declaration,
+      $._local_function_declaration,
+      $._local_class_declaration,
+    ],
   ],
 
   extras: ($) => [
@@ -783,7 +791,8 @@ module.exports = grammar({
         )
       ),
 
-    capture_list: ($) => seq("[", sep1($._capture_list_item, ","), "]"),
+    capture_list: ($) =>
+      seq(repeat($.attribute), "[", sep1($._capture_list_item, ","), "]"),
 
     _capture_list_item: ($) =>
       choice(

--- a/grammar.ts
+++ b/grammar.ts
@@ -1323,7 +1323,7 @@ module.exports = grammar({
     class_body: ($) => seq("{", optional($._class_member_declarations), "}"),
 
     _inheritance_specifiers: ($) =>
-      prec.left(sep1($.inheritance_specifier, choice(",", "&"))),
+      prec.left(sep1($._annotated_inheritance_specifier, choice(",", "&"))),
 
     inheritance_specifier: ($) =>
       prec.left(choice($.user_type, $.function_type)),


### PR DESCRIPTION
- Support attributes within lambda literals
- Support annotated inheritance specifiers
