### PR TITLE
Allow a class to be defined on one line

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -364,6 +364,48 @@ class SomethingElse: ThingProvider {
                             (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
                         (control_transfer_statement (simple_identifier)))))
             (function_declaration (simple_identifier) (function_body)))))
+
+===
+Class declaration without any newlines
+===
+
+class Dog { let noise: String = "bark" }
+class Cat { let noise: String = "meow"; let claws: String = "retractable" }
+
+---
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (line_string_literal))))
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (line_string_literal))
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (line_string_literal)))))
+
 ===
 Protocol composition types
 ===

--- a/grammar.ts
+++ b/grammar.ts
@@ -1354,7 +1354,7 @@ module.exports = grammar({
       ),
 
     _class_member_declarations: ($) =>
-      repeat1(seq($._type_level_declaration, $._semi)),
+      seq(sep1($._type_level_declaration, $._semi), optional($._semi)),
 
     _function_value_parameters: ($) =>
       seq("(", optional(sep1($._function_value_parameter, ",")), ")"),
@@ -1456,7 +1456,7 @@ module.exports = grammar({
       seq("{", optional($._protocol_member_declarations), "}"),
 
     _protocol_member_declarations: ($) =>
-      repeat1(seq($._protocol_member_declaration, $._semi)),
+      seq(sep1($._protocol_member_declaration, $._semi), optional($._semi)),
 
     _protocol_member_declaration: ($) =>
       choice(


### PR DESCRIPTION
Allows the final `_semi` (whether it's a real one or implied by
whitespace) to be omitted if a caller desires.
