### PR TITLE
Allow declarations that start with a multiline comment

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -45,6 +45,8 @@ Class with methods and expressions
 ==================
 
 class Strings {
+    /// Some awesome docummentation!
+    /// Yay
     func aString() -> String { return "Hello World!" }
 
     func anotherString() -> String { return "Hello" + " " + "World" }
@@ -55,6 +57,8 @@ class Strings {
 (source_file
     (class_declaration (type_identifier)
         (class_body
+            (comment)
+            (comment)
             (function_declaration
                 (simple_identifier)
                 (user_type (type_identifier))
@@ -77,7 +81,7 @@ Class with modifiers
 internal open class Test {
     private(set) var isRunning: Bool
     internal(set) var isFailed: Bool
-    private final func test() { }
+    /* some comment */ private final func test() { }
 }
 
 ---
@@ -95,6 +99,7 @@ internal open class Test {
                 (modifiers (visibility_modifier))
                 (value_binding_pattern (non_binding_pattern (simple_identifier)))
                 (type_annotation (user_type (type_identifier))))
+            (multiline_comment)
             (function_declaration
                 (modifiers (visibility_modifier) (inheritance_modifier))
                 (simple_identifier)

--- a/grammar.ts
+++ b/grammar.ts
@@ -1399,8 +1399,12 @@ module.exports = grammar({
         $._type
       ),
 
+    _class_member_separator: ($) => choice($._semi, $.multiline_comment),
     _class_member_declarations: ($) =>
-      seq(sep1($._type_level_declaration, $._semi), optional($._semi)),
+      seq(
+        sep1($._type_level_declaration, $._class_member_separator),
+        optional($._class_member_separator)
+      ),
 
     _function_value_parameters: ($) =>
       seq("(", optional(sep1($._function_value_parameter, ",")), ")"),

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -3,4 +3,3 @@ RxSwift/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchReposi
 RxSwift/Rx.playground/Pages/Transforming_Operators.xcplaygroundpage/Contents.swift
 SwiftLint/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
 GRDB/GRDB/Core/Row.swift
-GRDB/GRDB/Core/Statement.swift


### PR DESCRIPTION
The semi-suppressor is a little too aggressive: if it sees something
like:

```
class Foo {
    let property1: String

    /* visible for testing */ var property2: String
}
```

It will suppress the newlines before `property2` and cause compilation
to fail. If the comment were on its own line, it would be fine, because
there's still another semi in the way.

The best way to fix this seems to be to allow multiline comments
themselves to count as separators.
