### PR TITLE
Add a badge for parse rate

### DIFF
--- a/.github/workflows/top-repos.yml
+++ b/.github/workflows/top-repos.yml
@@ -22,3 +22,19 @@ jobs:
         cache: 'npm'
     - run: npm install
     - run: ./scripts/top-repos.sh ${{matrix.repo}}
+  badge_gen:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - id: parse_rate
+        run: echo "##[set-output name=parse_rate;]$(./scripts/calculate-parse-rate.sh)"
+      - name: BYOB
+        if: ${{ github.event_name == 'push' }}
+        uses: RubbaBoy/BYOB@v1.3.0
+        with:
+            NAME: parse_rate
+            LABEL: 'Parse rate'
+            STATUS: ${{ steps.parse_rate.outputs.parse_rate }}
+            COLOR: blue
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Parse rate badge](https://byob.yarr.is/alex-pinkus/experimental-tree-sitter-swift/parse_rate)
+
 # experimental-tree-sitter-swift
 
 This contains an experimental [`tree-sitter`](https://tree-sitter.github.io/tree-sitter) grammar for the Swift

--- a/scripts/calculate-parse-rate.sh
+++ b/scripts/calculate-parse-rate.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+parser_dir="$(pwd)"
+
+. $parser_dir/scripts/common.sh
+
+# Check out every repository to figure out how many files they contain.
+cd $tmpdir
+while read line ; do
+    checkout $line
+done < $top_repositories
+
+file_count=$(find "$tmpdir" -name *.swift -not -path '*/Pods/*' | wc -l)
+error_count=$(wc -l < $known_failures)
+
+# Now, since we can assume that the "top-repos" workflow ran, our parse rate is the number of
+# successful files over the number of total files. Pretty print that to two decimal places.
+printf '%.2f%%\n' $(bc -l <<< "($file_count - $error_count) / $file_count * 100")

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+known_failures="$parser_dir/script-data/known_failures.txt"
+top_repositories="$parser_dir/script-data/top-repositories.txt"
+
+# Run all this logic in a temporary directory that we delete on exit
+tmpdir="$(mktemp -d -t top-10-XXXXXX)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Function to check out a git repository at a given tag.
+#
+# We use tags so that the source code is deterministic - tags are immutable and reasonable people
+# don't delete and recreate them. The tree-sitter-python script this is based on uses raw SHA hashes
+# for this, but that would require us to checkout the code at HEAD first and switch to the code at
+# the given hash. Using tags means we can do this in one command and include `--depth 1` to reduce
+# the number of extra objects we have to fetch.
+function checkout() {
+  repo=$1; url=$2; tag=$3
+
+  if [ ! -d "$repo" ]; then
+    git clone --quiet --branch $tag --depth 1 "https://github.com/$url" "$repo" >/dev/null 2>/dev/null
+  fi
+}
+
+
+# Locates all the swift source code files that exist in the source tree under the passed-in
+# directory.
+#
+# Does not include code that gets included from dependencies of this repository, to avoid
+# overcounting those files.
+function swift_files_under() {
+    find "$1" -name *.swift -not -path '*/Pods/*'
+}


### PR DESCRIPTION
This uses the Bring Your Own Badge github action, running a script to
count the number of swift files and generate a percent based on the
count of files in `known_failures`.

This script only runs once the top-repos job has completed,
successfully, on a code push, so all it needs to do is compare
`known_failures` against the number of Swift files in the repos.
