### PR TITLE
Use the custom scanner to split ! from .

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -490,6 +490,33 @@ for i in 0 ..< something.count {
                 (navigation_suffix (simple_identifier))))
             (comment)))
 
+===
+Range with force unwrapped contents
+===
+
+_ = contents[Int(prefix)!...]
+
+---
+
+(source_file
+  (assignment
+    (directly_assignable_expression
+      (simple_identifier))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (open_end_range_expression
+              (postfix_expression
+                (call_expression
+                  (simple_identifier)
+                  (call_suffix
+                    (value_arguments
+                      (value_argument
+                        (simple_identifier)))))))))))))
+
+
 ============
 Split nullable navigation expression
 ============
@@ -677,10 +704,11 @@ print(thing.maybeGreeting!.definitely)
       (value_arguments
         (value_argument
           (navigation_expression
-            (navigation_expression
-              (simple_identifier)
+            (postfix_expression
+              (navigation_expression
+                (simple_identifier)
               (navigation_suffix
-                (simple_identifier)))
+                (simple_identifier))))
             (navigation_suffix
               (simple_identifier))))))))
 
@@ -879,3 +907,22 @@ for try await value in values {
           (value_arguments
             (value_argument
               (simple_identifier))))))))
+
+===
+Negation at the start of a line
+===
+
+
+let a = false
+
+!a
+
+---
+
+(source_file
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (boolean_literal))
+  (simple_identifier))

--- a/grammar.ts
+++ b/grammar.ts
@@ -220,6 +220,7 @@ module.exports = grammar({
     $._eq_eq,
     $._plus_then_ws, // + symbol with whitespace after it
     $._minus_then_ws, // - symbol with whitespace after it
+    $._bang,
     $._throws_keyword,
     $._rethrows_keyword,
     $.default_keyword,
@@ -628,14 +629,7 @@ module.exports = grammar({
     indexing_suffix: ($) => seq("[", sep1($._expression, ","), "]"),
 
     navigation_suffix: ($) =>
-      seq(
-        $._navigation_operator,
-        choice($.simple_identifier, $.integer_literal)
-      ),
-
-    // `!.` should just be the result of a postfix `!` before navigation, but it gets parsed as a
-    // custom infix operator instead.
-    _navigation_operator: ($) => choice($._dot_operator, "!."),
+      seq($._dot_operator, choice($.simple_identifier, $.integer_literal)),
 
     call_suffix: ($) =>
       prec(
@@ -974,7 +968,7 @@ module.exports = grammar({
     _key_path_postfixes: ($) =>
       choice(
         "?",
-        "!",
+        $._bang,
         "self",
         seq("[", optional(sep1($.value_argument, ",")), "]")
       ),
@@ -1003,7 +997,7 @@ module.exports = grammar({
           "--",
           "-",
           "+",
-          "!",
+          $._bang,
           "&",
           "~",
           $._dot_operator,
@@ -1013,7 +1007,7 @@ module.exports = grammar({
 
     _bitwise_binary_operator: ($) => choice("&", "|", "^", "<<", ">>"),
 
-    _postfix_unary_operator: ($) => choice("++", "--", "!"),
+    _postfix_unary_operator: ($) => choice("++", "--", $._bang),
 
     directly_assignable_expression: ($) =>
       choice(
@@ -1427,7 +1421,7 @@ module.exports = grammar({
       ),
 
     _constructor_function_decl: ($) =>
-      seq("init", optional(choice($._quest, "!"))),
+      seq("init", optional(choice($._quest, $._bang))),
 
     _non_constructor_function_decl: ($) =>
       seq(
@@ -1449,7 +1443,7 @@ module.exports = grammar({
         $._comparison_operator,
         "++",
         "--",
-        "!",
+        $._bang,
         "~"
       ),
 


### PR DESCRIPTION
So far, we've tolerated the parser treating `!.` as one operator when it
should really be two. This changes that behavior so that we better match
the actual semantics of `!.`, which is a bang-operator followed by
navigation.

We do this by adding `!` to the custom scanner, but this also requires
us to generalize the custom scanner's operators and indicate that they
are not all cross-semi operators. That's because `!` at the start of a
line is valid (although it will usually result in a warning) - it gives
us a standalone expression that negates what comes after the `!`.
