### PR TITLE
Add queries for syntax highlighting

### DIFF
--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -64,15 +64,15 @@ class Strings {
                 (user_type (type_identifier))
                 (function_body
                     (statements
-                        (control_transfer_statement (line_string_literal)))))
+                        (control_transfer_statement (line_string_literal (line_str_text))))))
             (function_declaration (simple_identifier) (user_type (type_identifier)) (function_body
                 (statements
                     (control_transfer_statement
                         (additive_expression
                             (additive_expression
-                                (line_string_literal)
-                                (line_string_literal))
-                            (line_string_literal)))))))))
+                                (line_string_literal (line_str_text))
+                                (line_string_literal (line_str_text)))
+                            (line_string_literal (line_str_text))))))))))
 
 ==================
 Class with modifiers
@@ -144,7 +144,7 @@ class Test : Protocol {
                     (attribute
                         (user_type (type_identifier))
                         (simple_identifier)
-                        (line_string_literal)))
+                        (line_string_literal (line_str_text))))
                     (simple_identifier)
                     (external_parameter_name)
                     (parameter (simple_identifier) (user_type (type_identifier)))
@@ -250,6 +250,7 @@ class Subscriptable {
             (user_type
               (type_identifier))
             (type_constraints
+              (where_keyword)
               (type_constraint
                 (inheritance_constraint
                   (identifier
@@ -366,6 +367,7 @@ class SomethingElse: ThingProvider {
                         (guard_statement
                             (value_binding_pattern (non_binding_pattern (simple_identifier)))
                             (simple_identifier)
+                            (else)
                             (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
                         (control_transfer_statement (simple_identifier)))))
             (function_declaration (simple_identifier) (function_body)))))
@@ -390,7 +392,7 @@ class Cat { let noise: String = "meow"; let claws: String = "retractable" }
         (type_annotation
           (user_type
             (type_identifier)))
-        (line_string_literal))))
+        (line_string_literal (line_str_text)))))
   (class_declaration
     (type_identifier)
     (class_body
@@ -401,7 +403,7 @@ class Cat { let noise: String = "meow"; let claws: String = "retractable" }
         (type_annotation
           (user_type
             (type_identifier)))
-        (line_string_literal))
+        (line_string_literal (line_str_text)))
       (property_declaration
         (value_binding_pattern
           (non_binding_pattern
@@ -409,7 +411,7 @@ class Cat { let noise: String = "meow"; let claws: String = "retractable" }
         (type_annotation
           (user_type
             (type_identifier)))
-        (line_string_literal)))))
+        (line_string_literal (line_str_text))))))
 
 ===
 Protocol composition types
@@ -498,6 +500,7 @@ protocol Wrapper {
                 (simple_identifier)
                 (optional_type (user_type (type_identifier) (type_identifier)))
                 (type_constraints
+                    (where_keyword)
                     (type_constraint
                         (inheritance_constraint
                             (identifier
@@ -519,6 +522,7 @@ protocol Wrapper {
                 (type_identifier)
                 (user_type (type_identifier))
                 (type_constraints
+                    (where_keyword)
                     (type_constraint
                         (equality_constraint
                             (identifier (simple_identifier) (simple_identifier))
@@ -724,7 +728,7 @@ enum CStyle {
                 (type_annotation (user_type (type_identifier)))
                 (call_expression
                     (prefix_expression (simple_identifier))
-                    (call_suffix (value_arguments (value_argument (line_string_literal))))))
+                    (call_suffix (value_arguments (value_argument (line_string_literal (line_str_text)))))))
             (enum_entry
                 (simple_identifier)
                 (enum_type_parameters (simple_identifier) (user_type (type_identifier))))
@@ -755,7 +759,7 @@ enum CStyle {
                 (simple_identifier)
                 (function_body
                     (statements
-                        (control_transfer_statement (line_string_literal)))))))
+                        (control_transfer_statement (line_string_literal (line_str_text))))))))
     (class_declaration
         (type_identifier)
         (enum_class_body
@@ -788,15 +792,16 @@ public extension Foo where T == (arg1: Arg1, arg2: Arg2) { }
         (property_declaration
             (modifiers (property_modifier))
             (value_binding_pattern (non_binding_pattern (simple_identifier)))
-            (line_string_literal))
+            (line_string_literal (line_str_text)))
         (property_declaration
             (modifiers (property_modifier))
             (value_binding_pattern (non_binding_pattern (simple_identifier)))
             (type_annotation (user_type (type_identifier)))
-            (line_string_literal)))) 
+            (line_string_literal (line_str_text))))) 
     (class_declaration
         (identifier (simple_identifier))
         (type_constraints
+            (where_keyword)
             (type_constraint
                 (inheritance_constraint
                     (identifier (simple_identifier))
@@ -810,6 +815,7 @@ public extension Foo where T == (arg1: Arg1, arg2: Arg2) { }
         (modifiers (visibility_modifier))
         (identifier (simple_identifier))
         (type_constraints
+            (where_keyword)
             (type_constraint
                 (equality_constraint
                     (identifier (simple_identifier))
@@ -853,7 +859,7 @@ enum ComputeType {
                     (user_type (type_identifier))
                     (simple_identifier)
                     (simple_identifier)
-                    (line_string_literal)))
+                    (line_string_literal (line_str_text))))
                 (simple_identifier)
                 (function_body))
             (property_declaration
@@ -861,7 +867,7 @@ enum ComputeType {
                     (user_type (type_identifier))
                     (simple_identifier)
                     (simple_identifier)
-                    (line_string_literal)))
+                    (line_string_literal (line_str_text))))
                 (value_binding_pattern (non_binding_pattern (simple_identifier)))
                 (type_annotation (user_type (type_identifier))))
             (function_declaration
@@ -885,7 +891,7 @@ enum ComputeType {
                     (user_type (type_identifier))
                     (simple_identifier)
                     (simple_identifier)
-                    (line_string_literal)))
+                    (line_string_literal (line_str_text))))
                 (simple_identifier)))))
 
 ===
@@ -920,7 +926,7 @@ let result: HasGeneric<P1 & P2> = HasGeneric<P1 & P2>(t: "Hello")
       (constructor_suffix
         (value_argument
           (simple_identifier)
-          (line_string_literal))))))
+          (line_string_literal (line_str_text)))))))
 
 
 ===
@@ -942,6 +948,7 @@ func iterate<S>(h: S) where S : Sequence, S.Element == P1 & P2 { }
       (user_type
         (type_identifier)))
     (type_constraints
+      (where_keyword)
       (type_constraint
         (inheritance_constraint
           (identifier
@@ -1002,7 +1009,8 @@ let result = greet("me") as P1 & P2
         (call_suffix
           (value_arguments
             (value_argument
-              (line_string_literal)))))
+              (line_string_literal (line_str_text))))))
+      (as_operator)
       (user_type
         (type_identifier))
       (user_type
@@ -1094,7 +1102,7 @@ public var someVar: String {
           (simple_identifier))
         (getter_specifier)
         (statements
-            (line_string_literal))))))
+            (line_string_literal (line_str_text)))))))
 
 ===
 Annotations on inheritance

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -319,14 +319,14 @@ something.hello?("world")
 (source_file
     (call_expression (simple_identifier)
         (call_suffix (value_arguments
-            (value_argument (line_string_literal)))))
+            (value_argument (line_string_literal (line_str_text))))))
     (call_expression (simple_identifier)
         (call_suffix (value_arguments
             (value_argument (integer_literal))
             (value_argument (integer_literal)))))
     (call_expression
         (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
-        (call_suffix (value_arguments (value_argument (line_string_literal))))))
+        (call_suffix (value_arguments (value_argument (line_string_literal (line_str_text)))))))
 
 ==================
 Constructor calls

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -163,9 +163,9 @@ func returnGetsImplicitlyUnwrapped() -> String! {
             (statements
                 (control_transfer_statement
                     (dictionary_literal
-                        (line_string_literal) (integer_literal)
-                        (line_string_literal) (integer_literal)
-                        (line_string_literal) (integer_literal))))))
+                        (line_string_literal (line_str_text)) (integer_literal)
+                        (line_string_literal (line_str_text)) (integer_literal)
+                        (line_string_literal (line_str_text)) (integer_literal))))))
     (function_declaration
         (simple_identifier)
         (user_type (type_identifier))
@@ -294,7 +294,7 @@ let messageCoerced = error ??? "nil"
     (infix_expression
       (simple_identifier)
       (custom_operator)
-      (line_string_literal))))
+      (line_string_literal (line_str_text)))))
 
 ==================
 Functions that throw
@@ -310,14 +310,14 @@ func iCanDoBetter()
 (source_file
     (function_declaration
         (simple_identifier)
-                (throws_modifier)
+                (throws)
         (user_type (type_identifier))
         (function_body
             (statements
                 (control_transfer_statement (prefix_expression (integer_literal))))))
     (function_declaration
         (simple_identifier)
-        (throws_modifier)
+        (throws)
         (user_type (type_identifier))
         (function_body
             (statements
@@ -339,15 +339,15 @@ func maybe()
 (source_file
     (function_declaration
         (simple_identifier)
-                (async_modifier)
+                (async)
         (user_type (type_identifier))
         (function_body
             (statements
                 (control_transfer_statement (prefix_expression (integer_literal))))))
     (function_declaration
         (simple_identifier)
-        (async_modifier)
-        (throws_modifier)
+        (async)
+        (throws)
         (user_type (type_identifier))
         (function_body
             (statements
@@ -371,7 +371,7 @@ func test(i: Int = 0, block: (Int) throws -> Void) {}
             (function_type
             (tuple_type
                 (user_type (type_identifier)))
-            (throws_modifier)
+            (throws)
             (user_type (type_identifier))))
         (function_body)))
 
@@ -566,7 +566,7 @@ private lazy var onCatClosure: (_ cat: Cat) throws -> Void = { _ in
                     (wildcard_pattern)
                     (simple_identifier)
                     (user_type (type_identifier)))
-                (throws_modifier)
+                (throws)
                 (user_type (type_identifier))))
         (lambda_literal
             (lambda_function_type (lambda_function_type_parameters (simple_identifier))))))

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -35,9 +35,12 @@ string.
 ---
 
 (source_file
-    (line_string_literal)
-    (multi_line_string_literal)
-    (line_string_literal))
+    (line_string_literal (line_str_text))
+    (multi_line_string_literal
+        (multi_line_str_text)
+        (multi_line_str_text)
+        (multi_line_str_text))
+    (line_string_literal (line_str_text)))
 
 ==================
 String interpolation
@@ -58,10 +61,17 @@ Multiline
 ---
 
 (source_file
-    (line_string_literal (interpolated_expression (line_string_literal)))
+    (line_string_literal
+        (line_str_text)
+        (interpolated_expression (line_string_literal (line_str_text)))
+        (line_str_text))
     (multi_line_string_literal
-        (interpolated_expression (multi_line_string_literal)))
-    (line_string_literal) (multi_line_string_literal) (comment))
+        (multi_line_str_text)
+        (interpolated_expression (multi_line_string_literal (multi_line_str_text)))
+        (multi_line_str_text))
+    (line_string_literal (line_str_text))
+    (multi_line_string_literal (multi_line_str_text))
+    (comment))
 
 ==================
 Custom interpolation
@@ -72,6 +82,7 @@ Custom interpolation
 
 (source_file
   (line_string_literal
+    (line_str_text)
     (interpolated_expression
       (simple_identifier)
       (simple_identifier))))
@@ -88,7 +99,11 @@ This is a string that acts as though it \
 
 ---
 
-(source_file (multi_line_string_literal))
+(source_file
+  (multi_line_string_literal
+    (multi_line_str_text)
+    (str_escaped_char)
+    (multi_line_str_text)))
 
 ==================
 Integer literals
@@ -149,10 +164,10 @@ let numerals = [1: "I", 4: "IV", 5: "V", 10: "X"]
         (value_binding_pattern
             (non_binding_pattern (simple_identifier)))
         (dictionary_literal
-            (integer_literal) (line_string_literal)
-            (integer_literal) (line_string_literal)
-            (integer_literal) (line_string_literal)
-            (integer_literal) (line_string_literal))))
+            (integer_literal) (line_string_literal (line_str_text))
+            (integer_literal) (line_string_literal (line_str_text))
+            (integer_literal) (line_string_literal (line_str_text))
+            (integer_literal) (line_string_literal (line_str_text)))))
 =====
 Trailing commas
 =====
@@ -168,13 +183,13 @@ Trailing commas
 
 (source_file
     (dictionary_literal
-        (line_string_literal)
+        (line_string_literal (line_str_text))
         (call_expression
             (navigation_expression
                 (simple_identifier)
                 (navigation_suffix (simple_identifier)))
             (call_suffix (value_arguments)))
-        (line_string_literal)
+        (line_string_literal (line_str_text))
         (boolean_literal))
     (array_literal
         (integer_literal) (integer_literal) (integer_literal) (integer_literal) (integer_literal)))
@@ -331,17 +346,17 @@ let infinity = "\u{221E}"
     (value_binding_pattern
       (non_binding_pattern
         (simple_identifier)))
-    (line_string_literal))
+    (line_string_literal (str_escaped_char)))
   (property_declaration
     (value_binding_pattern
       (non_binding_pattern
         (simple_identifier)))
-    (line_string_literal))
+    (line_string_literal (line_str_text) (str_escaped_char)))
   (property_declaration
     (value_binding_pattern
       (non_binding_pattern
         (simple_identifier)))
-    (line_string_literal)))
+    (line_string_literal (str_escaped_char))))
 
 ===
 Playground literals
@@ -357,5 +372,5 @@ let playgroundLiteral = #imageLiteral(resourceName: "heart")
       (non_binding_pattern
         (simple_identifier)))
     (simple_identifier)
-    (line_string_literal)))
+    (line_string_literal (line_str_text))))
 

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -85,6 +85,7 @@ for var value in values where value.isExcellent() {
         (non_binding_pattern (simple_identifier))
         (simple_identifier)
         (where_clause
+            (where_keyword)
             (call_expression
                 (navigation_expression
                     (simple_identifier)
@@ -189,16 +190,16 @@ switch something {
         (simple_identifier)
         (switch_entry
             (switch_pattern (simple_identifier))
-            (statements (control_transfer_statement (line_string_literal))))
+            (statements (control_transfer_statement (line_string_literal (line_str_text)))))
         (switch_entry
             (switch_pattern (simple_identifier))
-            (statements (control_transfer_statement (line_string_literal))))
+            (statements (control_transfer_statement (line_string_literal (line_str_text)))))
         (switch_entry
-            (switch_pattern (line_string_literal))
-            (statements (control_transfer_statement (line_string_literal))))
+            (switch_pattern (line_string_literal (line_str_text)))
+            (statements (control_transfer_statement (line_string_literal (line_str_text)))))
         (switch_entry
             (default_keyword)
-            (statements (control_transfer_statement (line_string_literal))))))
+            (statements (control_transfer_statement (line_string_literal (line_str_text)))))))
 
 ==================
 Weird switch statements
@@ -230,24 +231,25 @@ case let .isExecutable(path?):
             (statements (simple_identifier)))
         (switch_entry
             (switch_pattern (simple_identifier))
+            (where_keyword)
             (simple_identifier)
             (switch_pattern (simple_identifier))
             (statements (simple_identifier)))
         (switch_entry
             (modifiers (attribute (user_type (type_identifier))))
             (default_keyword)
-            (statements (control_transfer_statement (line_string_literal)))))
+            (statements (control_transfer_statement (line_string_literal (line_str_text))))))
     (switch_statement
         (self_expression)
         (switch_entry
             (switch_pattern
                     (simple_identifier)
                     (non_binding_pattern (simple_identifier)))
-            (statements (control_transfer_statement (line_string_literal (interpolated_expression (simple_identifier))))))
+            (statements (control_transfer_statement (line_string_literal (line_str_text) (interpolated_expression (simple_identifier))))))
         (switch_entry
             (switch_pattern
                 (non_binding_pattern (simple_identifier) (simple_identifier)))
-            (statements (control_transfer_statement (line_string_literal (interpolated_expression (simple_identifier))))))))
+            (statements (control_transfer_statement (line_string_literal (line_str_text) (interpolated_expression (simple_identifier))))))))
 
 ==================
 Imports
@@ -294,38 +296,44 @@ do {
                 (value_binding_pattern (non_binding_pattern (simple_identifier)))
                 (integer_literal)))
         (catch_block
+            (catch_keyword)
             (binding_pattern
                 (binding_pattern
                     (non_binding_pattern
                         (simple_identifier)))
                     (user_type (type_identifier))))
         (catch_block
+            (catch_keyword)
             (binding_pattern
                 (user_type (type_identifier))
                 (simple_identifier)))
         (catch_block
+            (catch_keyword)
             (binding_pattern
                 (binding_pattern
                     (non_binding_pattern
                         (simple_identifier)))
                     (user_type (type_identifier)))
             (where_clause
+                (where_keyword)
                 (equality_expression
                     (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
                     (integer_literal))))
         (catch_block
+            (catch_keyword)
             (binding_pattern
                 (non_binding_pattern
                     (user_type (type_identifier))
                     (simple_identifier)
                     (simple_identifier))))
         (catch_block
+            (catch_keyword)
             (binding_pattern
                 (user_type (type_identifier))
                 (simple_identifier)
                 (simple_identifier)
                 (non_binding_pattern (simple_identifier))))
-        (catch_block))
+        (catch_block (catch_keyword)))
     (do_statement
         (statements
             (property_declaration
@@ -400,7 +408,7 @@ func doSomething() {
                   (call_suffix
                      (value_arguments
                        (value_argument
-                         (line_string_literal))))))
+                         (line_string_literal (line_str_text)))))))
               (statements
                 (control_transfer_statement
                   (simple_identifier))))
@@ -459,9 +467,11 @@ else if let cPrime = c {
     (if_statement
         (value_binding_pattern (non_binding_pattern (simple_identifier)))
         (simple_identifier)
+        (else)
         (if_statement (value_binding_pattern (non_binding_pattern (simple_identifier))) (simple_identifier)))
     (if_statement
         (equality_expression (simple_identifier) (simple_identifier))
+        (else)
         (if_statement
             (value_binding_pattern (non_binding_pattern (simple_identifier)))
             (simple_identifier))))
@@ -489,6 +499,7 @@ else if bar {
         (integer_literal)))
     (comment)
     (comment)
+    (else)
     (if_statement
       (simple_identifier))))
 
@@ -515,16 +526,18 @@ guard case justIdentifier = bound else { }
     (guard_statement
         (value_binding_pattern (non_binding_pattern (simple_identifier)))
         (call_expression (simple_identifier) (call_suffix (value_arguments)))
+        (else)
         (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
     (guard_statement
         (call_expression (simple_identifier) (call_suffix (value_arguments)))
+        (else)
         (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
     (guard_statement
         (binding_pattern
             (simple_identifier) (simple_identifier)
             (non_binding_pattern (simple_identifier)))
-        (call_expression (simple_identifier) (call_suffix (value_arguments))))
-    (guard_statement (binding_pattern (simple_identifier)) (simple_identifier)))
+        (call_expression (simple_identifier) (call_suffix (value_arguments))) (else))
+    (guard_statement (binding_pattern (simple_identifier)) (simple_identifier) (else)))
 ==================
 Compound guard
 ==================
@@ -542,6 +555,7 @@ guard let something = doThing(), something.isSpecial() else {
         (call_expression
             (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
             (call_suffix (value_arguments)))
+        (else)
         (statements (call_expression (simple_identifier) (call_suffix (value_arguments))))))
 
 ===
@@ -566,6 +580,7 @@ guard case let size: Int = variable.size else {
       (simple_identifier)
       (navigation_suffix
         (simple_identifier)))
+    (else)
     (statements
       (control_transfer_statement))))
 
@@ -593,6 +608,7 @@ if #available(macOS 10.12.0, *) {
         (identifier (simple_identifier))
         (integer_literal) (integer_literal) (integer_literal))
         (statements (control_transfer_statement (integer_literal)))
+        (else)
         (statements (control_transfer_statement (integer_literal)))))
 
 

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -11,12 +11,15 @@ something as! A
 (source_file 
     (as_expression
         (simple_identifier)
+        (as_operator)
         (user_type (type_identifier)))
     (as_expression
         (simple_identifier)
+        (as_operator)
         (user_type (type_identifier)))
     (as_expression
         (simple_identifier)
+        (as_operator)
         (user_type (type_identifier))))
 
 ==================
@@ -30,6 +33,7 @@ something as Some.NestedType
 (source_file
     (as_expression
         (simple_identifier)
+        (as_operator)
         (user_type (type_identifier) (type_identifier))))
 
 ==================
@@ -43,6 +47,7 @@ somethingElse as A.Deeply.Nested.Type
 (source_file
     (as_expression
         (simple_identifier)
+        (as_operator)
         (user_type
             (type_identifier)
             (type_identifier)
@@ -61,11 +66,13 @@ something as Generic<A, Type>
 (source_file
     (as_expression
         (simple_identifier)
+        (as_operator)
         (user_type (type_identifier)
             (type_arguments
                 (user_type (type_identifier)))))
     (as_expression
         (simple_identifier)
+        (as_operator)
         (user_type (type_identifier)
             (type_arguments
                 (user_type (type_identifier))
@@ -84,16 +91,19 @@ configurator as (inout Config) -> Unit
 (source_file
     (as_expression
         (simple_identifier)
+        (as_operator)
         (function_type
             (tuple_type)
             (user_type (type_identifier))))
     (as_expression
         (simple_identifier)
+        (as_operator)
         (function_type
             (tuple_type (user_type (type_identifier)))
             (user_type (type_identifier))))
     (as_expression
         (simple_identifier)
+        (as_operator)
         (function_type
             (tuple_type
                 (parameter_modifiers (parameter_modifier))
@@ -112,6 +122,7 @@ b as (Nested.Type, (Int)) -> Unit
 (source_file
     (as_expression
         (simple_identifier)
+        (as_operator)
         (function_type
             (tuple_type
                 (user_type (type_identifier))
@@ -122,6 +133,7 @@ b as (Nested.Type, (Int)) -> Unit
             (user_type (type_identifier))))
     (as_expression
         (simple_identifier)
+        (as_operator)
         (function_type
             (tuple_type
                 (user_type (type_identifier) (type_identifier))
@@ -141,6 +153,7 @@ let c: (third: C, fourth: D)
 (source_file
     (as_expression
         (simple_identifier)
+        (as_operator)
         (function_type
             (tuple_type
                 (simple_identifier)
@@ -227,6 +240,7 @@ protocol GetType {
     (navigation_expression
       (as_expression
         (simple_identifier)
+        (as_operator)
         (array_type
           (user_type
             (type_identifier))))

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,130 @@
+; Identifiers
+(attribute) @variable
+(simple_identifier) @variable
+(type_identifier) @type
+(self_expression) @variable.builtin
+
+; Declarations
+"func" @keyword.function
+[
+  (visibility_modifier)
+  (member_modifier)
+  (function_modifier)
+  (property_modifier)
+  (parameter_modifier)
+  (inheritance_modifier)
+] @keyword
+
+(function_declaration (simple_identifier) @function.method)
+(function_declaration ["init" @constructor])
+(external_parameter_name) @parameter
+(throws) @keyword
+(async) @keyword
+(where_keyword) @keyword
+(parameter (simple_identifier) @parameter)
+(type_parameter (type_identifier) @parameter)
+(inheritance_constraint (identifier (simple_identifier) @parameter))
+(equality_constraint (identifier (simple_identifier) @parameter))
+
+["typealias" "struct" "class" "enum" "protocol" "extension"] @keyword
+
+(class_body (property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property))))
+(protocol_property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property)))
+
+(import_declaration ["import" @include])
+
+(enum_entry ["case" @keyword])
+
+; Function calls
+(call_expression (simple_identifier) @function) ; foo()
+(call_expression ; foo.bar.baz(): highlight the baz()
+  (navigation_expression
+    (navigation_suffix (simple_identifier) @function)))
+((navigation_expression
+   (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
+   (#lua-match? @type "^[A-Z]"))
+
+(directive) @function.macro
+(diagnostic) @function.macro
+
+; Statements
+(for_statement ["for" @repeat])
+(for_statement ["in" @repeat])
+(for_statement item: (simple_identifier) @variable)
+(else) @keyword
+(as_operator) @keyword
+
+["while" "repeat" "continue" "break"] @repeat
+
+["let" "var"] @keyword
+(non_binding_pattern (simple_identifier) @variable)
+
+(guard_statement ["guard" @conditional])
+(if_statement ["if" @conditional])
+(switch_statement ["switch" @conditional])
+(switch_entry ["case" @keyword])
+(switch_entry ["fallthrough" @keyword])
+(switch_entry (default_keyword) @keyword)
+"return" @keyword.return
+
+["do" (throw_keyword) (catch_keyword)] @keyword
+
+(statement_label) @label
+
+; Comments
+(comment) @comment
+(multiline_comment) @comment
+
+; String literals
+(line_str_text) @string
+(str_escaped_char) @string
+(multi_line_str_text) @string
+(raw_str_part) @string
+(raw_str_end_part) @string
+(raw_str_interpolation_start) @punctuation.special
+["\"" "\"\"\""] @string
+
+; Lambda literals
+(lambda_literal ["in" @keyword.operator])
+
+; Basic literals
+[
+ (integer_literal)
+ (hex_literal)
+ (oct_literal)
+ (bin_literal)
+] @number
+(real_literal) @float
+(boolean_literal) @boolean
+"nil" @variable.builtin
+
+; Operators
+(custom_operator) @operator
+[
+ "try"
+ "try?"
+ "try!"
+ "!"
+ "+"
+ "-"
+ "*"
+ "/"
+ "%"
+ "="
+ "+="
+ "-="
+ "*="
+ "/="
+ "<"
+ ">"
+ "<="
+ ">="
+ "++"
+ "--"
+ "&"
+ "~"
+ "%="
+ "!="
+ "!=="
+ "==="
+] @operator

--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -1,0 +1,18 @@
+(import_declaration (identifier) @definition.import)
+(function_declaration name: (simple_identifier) @definition.function)
+
+; Scopes
+[
+ (statements)
+ (for_statement)
+ (while_statement)
+ (repeat_while_statement)
+ (do_statement)
+ (if_statement)
+ (guard_statement)
+ (switch_statement)
+ (property_declaration)
+ (function_declaration)
+ (class_declaration)
+ (protocol_declaration)
+] @scope

--- a/script-data/known_failures.txt
+++ b/script-data/known_failures.txt
@@ -1,5 +1,4 @@
 firefox-ios/Shared/Functions.swift
 RxSwift/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositories.swift
 RxSwift/Rx.playground/Pages/Transforming_Operators.xcplaygroundpage/Contents.swift
-SwiftLint/Source/SwiftLintFramework/Extensions/String+SwiftLint.swift
 GRDB/GRDB/Core/Row.swift


### PR DESCRIPTION
Puts some basic syntax highlighting in place for keywords and
identifiers. This requires some nodes to lose their anonymity, in
particular any keyword that we wish to match from the custom scanner.
