### PR TITLE
Publish status badges for crates.io and npm packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,14 +2,17 @@ name: Publish to `npm` and `crates.io`
 
 on:
   workflow_run:
-    workflows: ["Parse popular Swift repositories"]
+    workflows: ["Parse top repositories"]
     types:
       - completed
 
 jobs:
-  npm-publish:
+  npm_publish:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    outputs:
+      type: ${{ steps.npm_publish.outputs.type }}
+      package_version: ${{ steps.npm_publish.outputs.version }}
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -20,11 +23,13 @@ jobs:
       - run: npm run bindings
       - run: cd ./test-npm-package && npm test; cd ..
       - uses: JS-DevTools/npm-publish@v1
+        id: npm_publish
         with:
           token: ${{ secrets.NPM_TOKEN }}
-  crates-io-publish:
-    if: ${{ github.ref == 'refs/heads/main' }}
+  crates_io_publish:
     runs-on: ubuntu-latest
+    needs: npm_publish
+    if: ${{ needs.npm_publish.outputs.type != 'none' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -38,3 +43,25 @@ jobs:
         with:
             registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
             args: --allow-dirty
+  badge_update:
+    runs-on: ubuntu-latest
+    needs:
+      - npm_publish
+      - crates_io_publish
+    steps:
+      - name: Update crates.io badge
+        uses: RubbaBoy/BYOB@v1.3.0
+        with:
+          NAME: crates_io_version
+          LABEL: 'crates.io'
+          STATUS: ${{ needs.npm_publish.outputs.package_version }}
+          COLOR: green
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update npm badge
+        uses: RubbaBoy/BYOB@v1.3.0
+        with:
+          NAME: npm_version
+          LABEL: 'npm'
+          STATUS: ${{ needs.npm_publish.outputs.package_version }}
+          COLOR: green
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/top-repos.yml
+++ b/.github/workflows/top-repos.yml
@@ -1,4 +1,4 @@
-name: Parse popular Swift repositories
+name: Parse top repositories
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 ![Parse rate badge](https://byob.yarr.is/alex-pinkus/experimental-tree-sitter-swift/parse_rate)
+[![Crates.io badge](https://byob.yarr.is/alex-pinkus/experimental-tree-sitter-swift/crates_io_version)](https://crates.io/crates/experimental-tree-sitter-swift)
+[![NPM badge](https://byob.yarr.is/alex-pinkus/experimental-tree-sitter-swift/npm_version)](https://www.npmjs.com/package/experimental-tree-sitter-swift)
+[![Build](https://github.com/alex-pinkus/experimental-tree-sitter-swift/actions/workflows/top-repos.yml/badge.svg)](https://github.com/alex-pinkus/experimental-tree-sitter-swift/actions/workflows/top-repos.yml)
 
 # experimental-tree-sitter-swift
 


### PR DESCRIPTION
Assumes that the crates.io and npm versions will stay the same (they should) and uses the npm publish output as an input for a badge publishing job.

As a side effect, only runs the crates.io publish logic after updating the package in npm, because this will allow for batching of minor changes together under a single version update. The crates.io publish action will otherwise just fail if it doesn't like what it sees.

