### PR TITLE
Fix clean `npm install` behavior

### DIFF
--- a/.github/workflows/top-repos.yml
+++ b/.github/workflows/top-repos.yml
@@ -63,6 +63,7 @@ jobs:
         node-version: '16.x'
         cache: 'npm'
     - run: npm install
+    - run: npm run test-ci
     - run: ./scripts/top-repos.sh ${{matrix.repo}}
   badge_gen:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "nan": "^2.15.0"
-      },
-      "devDependencies": {
         "@types/node": "^16.11.10",
-        "node-gyp": "^8.4.1",
-        "prettier": "2.3.2",
+        "nan": "^2.15.0",
         "tree-sitter-cli": "^0.20.0",
         "typescript": "^4.5.2"
+      },
+      "devDependencies": {
+        "node-gyp": "^8.4.1",
+        "prettier": "2.3.2"
       }
     },
     "node_modules/@gar/promisify": {
@@ -63,8 +63,7 @@
     "node_modules/@types/node": {
       "version": "16.11.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
-      "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==",
-      "dev": true
+      "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA=="
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -968,7 +967,6 @@
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.0.tgz",
       "integrity": "sha512-4D1qapWbJXZ5rrSUGM5rcw5Vuq/smzn9KbiFRhlON6KeuuXjra+KAtDYVrDgAoLIG4ku+jbEEGrJxCptUGi3dg==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "tree-sitter": "cli.js"
@@ -978,7 +976,6 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
       "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1084,8 +1081,7 @@
     "@types/node": {
       "version": "16.11.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
-      "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==",
-      "dev": true
+      "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -1787,14 +1783,12 @@
     "tree-sitter-cli": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.0.tgz",
-      "integrity": "sha512-4D1qapWbJXZ5rrSUGM5rcw5Vuq/smzn9KbiFRhlON6KeuuXjra+KAtDYVrDgAoLIG4ku+jbEEGrJxCptUGi3dg==",
-      "dev": true
+      "integrity": "sha512-4D1qapWbJXZ5rrSUGM5rcw5Vuq/smzn9KbiFRhlON6KeuuXjra+KAtDYVrDgAoLIG4ku+jbEEGrJxCptUGi3dg=="
     },
     "typescript": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
-      "dev": true
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw=="
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "An experimental tree-sitter grammar for the Swift programming language.",
   "main": "bindings/node/index.js",
   "scripts": {
-    "install": "tsc && tree-sitter generate",
+    "install": "tsc && tree-sitter generate ./build/grammar.js",
+    "postinstall": "node-gyp configure && node-gyp build",
     "ci": "prettier --check grammar.ts types/*/*.d.ts",
     "test-ci": "./scripts/test-with-memcheck.sh --install-valgrind",
-    "test": "./scripts/test-with-memcheck.sh",
-    "bindings": "node-gyp configure && node-gyp build"
+    "test": "./scripts/test-with-memcheck.sh"
   },
   "repository": {
     "type": "git",
@@ -25,13 +25,13 @@
   },
   "homepage": "https://github.com/alex-pinkus/experimental-tree-sitter-swift#readme",
   "dependencies": {
-    "nan": "^2.15.0"
-  },
-  "devDependencies": {
     "@types/node": "^16.11.10",
-    "node-gyp": "^8.4.1",
-    "prettier": "2.3.2",
+    "nan": "^2.15.0",
     "tree-sitter-cli": "^0.20.0",
     "typescript": "^4.5.2"
+  },
+  "devDependencies": {
+    "node-gyp": "^8.4.1",
+    "prettier": "2.3.2"
   }
 }

--- a/scripts/test-with-memcheck.sh
+++ b/scripts/test-with-memcheck.sh
@@ -7,6 +7,8 @@ if [[ "$1" == "--install-valgrind" ]]; then
     shift
 fi
 
+tree-sitter generate
+
 # Query tests hang forever when run with valgrind, so move them out of
 # the way.
 mv ./queries ./queries.bak


### PR DESCRIPTION
Applies suggested fixes from #87:
* Pointing to `./build/grammar.js` in install command
* Putting `typescript` in `dependencies` rather than `devDependencies`
* Running `binding` during install (this change does it during
  `postinstall` rather than `preinstall` so that the `parser.c` is
  present when clean)