### PR TITLE
Add field names for common queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "experimental-tree-sitter-swift"
 description = "swift grammar for the tree-sitter parsing library"
-version = "0.0.1"
+version = "0.0.2"
 keywords = ["incremental", "parsing", "swift"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/alex-pinkus/experimental-tree-sitter-swift"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use this parser to parse Swift code, you'll want to depend on either the Rust
 To use the Rust crate, you'll add this to your `Cargo.toml`:
 ```
 tree-sitter = "0.20.0"
-experimental-tree-sitter-swift = "=0.0.1"
+experimental-tree-sitter-swift = "=0.0.2"
 ```
 
 Then you can use a `tree-sitter` parser with the language declared here:
@@ -36,7 +36,7 @@ let tree = parser.parse(&my_source_code, None)
 To use this from NPM, you'll add similar dependencies to `package.json`:
 ```
 "dependencies: {
-  "experimental-tree-sitter-swift": "0.0.1",
+  "experimental-tree-sitter-swift": "0.0.2",
   "tree-sitter": "^0.20.0"
 }
 ```

--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -1,17 +1,19 @@
-==================
+================================================================================
 Classes
-==================
+================================================================================
 
 class Empty {}
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration (type_identifier) (class_body)))
- 
-==================
+  (class_declaration
+    (type_identifier)
+    (class_body)))
+
+================================================================================
 Class with methods
-==================
+================================================================================
 
 class HelloWorld {
     func a() {}
@@ -19,30 +21,38 @@ class HelloWorld {
     func b() {}
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration (type_identifier)
-        (class_body
-            (function_declaration (simple_identifier) (function_body))
-            (function_declaration (simple_identifier) (function_body)))))
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (function_declaration
+        (simple_identifier)
+        (function_body))
+      (function_declaration
+        (simple_identifier)
+        (function_body)))))
 
-==================
+================================================================================
 Generic class
-==================
+================================================================================
 
 class Container<T> {}
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration (type_identifier)
-        (type_parameters (type_parameter (type_identifier)))
-        (class_body)))
+  (class_declaration
+    (type_identifier)
+    (type_parameters
+      (type_parameter
+        (type_identifier)))
+    (class_body)))
 
-==================
+================================================================================
 Class with methods and expressions
-==================
+================================================================================
 
 class Strings {
     /// Some awesome docummentation!
@@ -52,31 +62,42 @@ class Strings {
     func anotherString() -> String { return "Hello" + " " + "World" }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration (type_identifier)
-        (class_body
-            (comment)
-            (comment)
-            (function_declaration
-                (simple_identifier)
-                (user_type (type_identifier))
-                (function_body
-                    (statements
-                        (control_transfer_statement (line_string_literal (line_str_text))))))
-            (function_declaration (simple_identifier) (user_type (type_identifier)) (function_body
-                (statements
-                    (control_transfer_statement
-                        (additive_expression
-                            (additive_expression
-                                (line_string_literal (line_str_text))
-                                (line_string_literal (line_str_text)))
-                            (line_string_literal (line_str_text))))))))))
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (comment)
+      (comment)
+      (function_declaration
+        (simple_identifier)
+        (user_type
+          (type_identifier))
+        (function_body
+          (statements
+            (control_transfer_statement
+              (line_string_literal
+                (line_str_text))))))
+      (function_declaration
+        (simple_identifier)
+        (user_type
+          (type_identifier))
+        (function_body
+          (statements
+            (control_transfer_statement
+              (additive_expression
+                (additive_expression
+                  (line_string_literal
+                    (line_str_text))
+                  (line_string_literal
+                    (line_str_text)))
+                (line_string_literal
+                  (line_str_text))))))))))
 
-==================
+================================================================================
 Class with modifiers
-==================
+================================================================================
 
 internal open class Test {
     private(set) var isRunning: Bool
@@ -84,30 +105,44 @@ internal open class Test {
     /* some comment */ private final func test() { }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration
-        (modifiers (visibility_modifier) (visibility_modifier))
-        (type_identifier)
-        (class_body
-            (property_declaration
-                (modifiers (visibility_modifier))
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation (user_type (type_identifier))))
-            (property_declaration
-                (modifiers (visibility_modifier))
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation (user_type (type_identifier))))
-            (multiline_comment)
-            (function_declaration
-                (modifiers (visibility_modifier) (inheritance_modifier))
-                (simple_identifier)
-                (function_body)))))
+  (class_declaration
+    (modifiers
+      (visibility_modifier)
+      (visibility_modifier))
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (modifiers
+          (visibility_modifier))
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier))))
+      (property_declaration
+        (modifiers
+          (visibility_modifier))
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier))))
+      (multiline_comment)
+      (function_declaration
+        (modifiers
+          (visibility_modifier)
+          (inheritance_modifier))
+        (simple_identifier)
+        (function_body)))))
 
-==================
+================================================================================
 Class with annotations
-==================
+================================================================================
 
 @objc(Test)
 class Test : Protocol {
@@ -118,41 +153,53 @@ class Test : Protocol {
     func someFunction(nice argument: Int) { }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration
+  (class_declaration
+    (modifiers
+      (attribute
+        (user_type
+          (type_identifier))
+        (simple_identifier)))
+    (type_identifier)
+    (inheritance_specifier
+      (user_type
+        (type_identifier)))
+    (class_body
+      (function_declaration
         (modifiers
-            (attribute
-                (user_type (type_identifier))
-                (simple_identifier)))
-        (type_identifier)
-        (inheritance_specifier (user_type (type_identifier)))
-        (class_body
-            (function_declaration
-                (modifiers
-                    (attribute
-                        (user_type (type_identifier))
-                        (simple_identifier))
-                    (property_modifier))
-                    (simple_identifier)
-                    (external_parameter_name)
-                    (parameter (simple_identifier) (user_type (type_identifier)))
-                    (function_body))
-            (function_declaration
-                (modifiers
-                    (attribute
-                        (user_type (type_identifier))
-                        (simple_identifier)
-                        (line_string_literal (line_str_text))))
-                    (simple_identifier)
-                    (external_parameter_name)
-                    (parameter (simple_identifier) (user_type (type_identifier)))
-                    (function_body)))))
+          (attribute
+            (user_type
+              (type_identifier))
+            (simple_identifier))
+          (property_modifier))
+        (simple_identifier)
+        (parameter
+          (simple_identifier)
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (function_body))
+      (function_declaration
+        (modifiers
+          (attribute
+            (user_type
+              (type_identifier))
+            (simple_identifier)
+            (line_string_literal
+              (line_str_text))))
+        (simple_identifier)
+        (parameter
+          (simple_identifier)
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (function_body)))))
 
-==================
+================================================================================
 Class with subscript
-==================
+================================================================================
 
 class RequestManager {
     open subscript(task: Task) -> Request? {
@@ -171,54 +218,79 @@ class GenericSubscript {
     }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration
-        (type_identifier)
-        (class_body
-            (subscript_declaration
-                (modifiers (visibility_modifier))
-                (parameter (simple_identifier) (user_type (type_identifier)))
-                (optional_type (user_type (type_identifier)))
-                (computed_getter
-                    (getter_specifier)
-                    (statements
-                        (control_transfer_statement
-                            (call_expression (simple_identifier)
-                                (call_suffix
-                                    (value_arguments
-                                        (value_argument
-                                            (navigation_expression
-                                                (simple_identifier)
-                                                (navigation_suffix (simple_identifier))))))))))
-                (computed_setter
-                    (setter_specifier)
-                    (statements
-                        (assignment
-                            (directly_assignable_expression
-                                (call_expression
-                                    (simple_identifier)
-                                    (call_suffix
-                                        (value_arguments
-                                            (value_argument
-                                                (navigation_expression
-                                                (simple_identifier)
-                                                (navigation_suffix (simple_identifier))))))))
-                            (simple_identifier)))))))
-    (class_declaration
-        (type_identifier)
-        (class_body
-            (subscript_declaration
-                (modifiers (visibility_modifier))
-                (type_parameters (type_parameter (type_identifier)))
-                (external_parameter_name)
-                (parameter (simple_identifier) (user_type (type_identifier) (type_arguments (user_type (type_identifier)))))
-                (user_type (type_identifier) (type_arguments (user_type (type_identifier))))
-                (statements (control_transfer_statement (simple_identifier)))))))
-===
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (subscript_declaration
+        (modifiers
+          (visibility_modifier))
+        (parameter
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (optional_type
+          (user_type
+            (type_identifier)))
+        (computed_getter
+          (getter_specifier)
+          (statements
+            (control_transfer_statement
+              (call_expression
+                (simple_identifier)
+                (call_suffix
+                  (value_arguments
+                    (value_argument
+                      (navigation_expression
+                        (simple_identifier)
+                        (navigation_suffix
+                          (simple_identifier))))))))))
+        (computed_setter
+          (setter_specifier)
+          (statements
+            (assignment
+              (directly_assignable_expression
+                (call_expression
+                  (simple_identifier)
+                  (call_suffix
+                    (value_arguments
+                      (value_argument
+                        (navigation_expression
+                          (simple_identifier)
+                          (navigation_suffix
+                            (simple_identifier))))))))
+              (simple_identifier)))))))
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (subscript_declaration
+        (modifiers
+          (visibility_modifier))
+        (type_parameters
+          (type_parameter
+            (type_identifier)))
+        (parameter
+          (simple_identifier)
+          (simple_identifier)
+          (user_type
+            (type_identifier)
+            (type_arguments
+              (user_type
+                (type_identifier)))))
+        (user_type
+          (type_identifier)
+          (type_arguments
+            (user_type
+              (type_identifier))))
+        (statements
+          (control_transfer_statement
+            (simple_identifier)))))))
+
+================================================================================
 Subscript with multiple arguments
-===
+================================================================================
 
 class Subscriptable {
     public subscript<D>(_ value: D, arg2: Arg2) -> D where D: Decodable {
@@ -226,65 +298,71 @@ class Subscriptable {
     }
 }
 
----
+--------------------------------------------------------------------------------
 
-    (source_file
-      (class_declaration
-        (type_identifier)
-        (class_body
-          (subscript_declaration
-            (modifiers
-              (visibility_modifier))
-            (type_parameters
-              (type_parameter
-                (type_identifier)))
-            (external_parameter_name)
-            (parameter
-              (simple_identifier)
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (subscript_declaration
+        (modifiers
+          (visibility_modifier))
+        (type_parameters
+          (type_parameter
+            (type_identifier)))
+        (parameter
+          (simple_identifier)
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (parameter
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (user_type
+          (type_identifier))
+        (type_constraints
+          (where_keyword)
+          (type_constraint
+            (inheritance_constraint
+              (identifier
+                (simple_identifier))
               (user_type
-                (type_identifier)))
-            (parameter
-              (simple_identifier)
-              (user_type
-                (type_identifier)))
-            (user_type
-              (type_identifier))
-            (type_constraints
-              (where_keyword)
-              (type_constraint
-                (inheritance_constraint
-                  (identifier
-                    (simple_identifier))
-                  (user_type
-                    (type_identifier)))))
-            (statements
-              (control_transfer_statement
-                (simple_identifier)))))))
+                (type_identifier)))))
+        (statements
+          (control_transfer_statement
+            (simple_identifier)))))))
 
-==================
+================================================================================
 Inheritance
-==================
+================================================================================
 
 class A : B {}
 
 class D : Protocol1 & Protocol2 { }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration
-        (type_identifier)
-        (inheritance_specifier (user_type (type_identifier)))
-        (class_body))
-    (class_declaration
-        (type_identifier)
-        (inheritance_specifier (user_type (type_identifier)))
-        (inheritance_specifier (user_type (type_identifier)))
-        (class_body)))
+  (class_declaration
+    (type_identifier)
+    (inheritance_specifier
+      (user_type
+        (type_identifier)))
+    (class_body))
+  (class_declaration
+    (type_identifier)
+    (inheritance_specifier
+      (user_type
+        (type_identifier)))
+    (inheritance_specifier
+      (user_type
+        (type_identifier)))
+    (class_body)))
 
-==================
+================================================================================
 Properties
-==================
+================================================================================
 
 class Something {
     let u: Int = 4
@@ -312,74 +390,123 @@ class SomethingElse: ThingProvider {
     class func nothing() { }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration
-        (type_identifier)
-        (class_body
-            (property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation
-                    (user_type (type_identifier)))
-                (integer_literal))
-            (property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation
-                    (optional_type (user_type (type_identifier)))))
-            (property_declaration
-                (modifiers (property_behavior_modifier))
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation
-                (user_type (type_identifier)))
-                (simple_identifier))
-            (property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation
-                    (user_type (type_identifier)))
-                (computed_property (statements (simple_identifier))))
-            (property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation
-                    (user_type (type_identifier)))
-                    (computed_property
-                        (computed_getter (getter_specifier) (statements (simple_identifier)))
-                        (computed_setter (setter_specifier) (simple_identifier))))
-            (property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation (user_type (type_identifier)))
-                (computed_property
-                    (computed_getter (getter_specifier) (statements (simple_identifier)))
-                    (computed_setter
-                        (setter_specifier)
-                        (statements
-                            (control_transfer_statement
-                                (assignment (directly_assignable_expression (simple_identifier)) (simple_identifier)))))))))
-    (class_declaration
-        (type_identifier)
-        (inheritance_specifier (user_type (type_identifier)))
-        (class_body
-            (property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation (user_type (type_identifier)))
-                (computed_property
-                    (statements
-                        (guard_statement
-                            (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                            (simple_identifier)
-                            (else)
-                            (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
-                        (control_transfer_statement (simple_identifier)))))
-            (function_declaration (simple_identifier) (function_body)))))
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (integer_literal))
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (optional_type
+            (user_type
+              (type_identifier)))))
+      (property_declaration
+        (modifiers
+          (property_behavior_modifier))
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (simple_identifier))
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (computed_property
+          (statements
+            (simple_identifier))))
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (computed_property
+          (computed_getter
+            (getter_specifier)
+            (statements
+              (simple_identifier)))
+          (computed_setter
+            (setter_specifier)
+            (simple_identifier))))
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (computed_property
+          (computed_getter
+            (getter_specifier)
+            (statements
+              (simple_identifier)))
+          (computed_setter
+            (setter_specifier)
+            (statements
+              (control_transfer_statement
+                (assignment
+                  (directly_assignable_expression
+                    (simple_identifier))
+                  (simple_identifier)))))))))
+  (class_declaration
+    (type_identifier)
+    (inheritance_specifier
+      (user_type
+        (type_identifier)))
+    (class_body
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (computed_property
+          (statements
+            (guard_statement
+              (value_binding_pattern
+                (non_binding_pattern
+                  (simple_identifier)))
+              (simple_identifier)
+              (else)
+              (statements
+                (call_expression
+                  (simple_identifier)
+                  (call_suffix
+                    (value_arguments)))))
+            (control_transfer_statement
+              (simple_identifier)))))
+      (function_declaration
+        (simple_identifier)
+        (function_body)))))
 
-===
+================================================================================
 Class declaration without any newlines
-===
+================================================================================
 
 class Dog { let noise: String = "bark" }
 class Cat { let noise: String = "meow"; let claws: String = "retractable" }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (class_declaration
@@ -392,7 +519,8 @@ class Cat { let noise: String = "meow"; let claws: String = "retractable" }
         (type_annotation
           (user_type
             (type_identifier)))
-        (line_string_literal (line_str_text)))))
+        (line_string_literal
+          (line_str_text)))))
   (class_declaration
     (type_identifier)
     (class_body
@@ -403,7 +531,8 @@ class Cat { let noise: String = "meow"; let claws: String = "retractable" }
         (type_annotation
           (user_type
             (type_identifier)))
-        (line_string_literal (line_str_text)))
+        (line_string_literal
+          (line_str_text)))
       (property_declaration
         (value_binding_pattern
           (non_binding_pattern
@@ -411,36 +540,37 @@ class Cat { let noise: String = "meow"; let claws: String = "retractable" }
         (type_annotation
           (user_type
             (type_identifier)))
-        (line_string_literal (line_str_text))))))
+        (line_string_literal
+          (line_str_text))))))
 
-===
+================================================================================
 Protocol composition types
-===
+================================================================================
 
 var propertyMap: NodePropertyMap & KeypathSearchable {
   return transformProperties
 }
 
----
+--------------------------------------------------------------------------------
 
-    (source_file
-      (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
-        (type_annotation
-          (user_type
-            (type_identifier))
-          (user_type
-            (type_identifier)))
-        (computed_property
-          (statements
-            (control_transfer_statement
-              (simple_identifier))))))
+(source_file
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (type_annotation
+      (user_type
+        (type_identifier))
+      (user_type
+        (type_identifier)))
+    (computed_property
+      (statements
+        (control_transfer_statement
+          (simple_identifier))))))
 
-==================
+================================================================================
 Structs
-==================
+================================================================================
 
 struct Adder {
     var value: Int
@@ -450,27 +580,33 @@ struct Adder {
     }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration
-        (type_identifier)
-        (class_body
-            (property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation
-                    (user_type (type_identifier))))
-            (function_declaration
-                (modifiers (mutation_modifier))
-                (simple_identifier)
-                (function_body
-                    (statements
-                        (assignment
-                            (directly_assignable_expression (simple_identifier))
-                            (integer_literal))))))))
-==================
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier))))
+      (function_declaration
+        (modifiers
+          (mutation_modifier))
+        (simple_identifier)
+        (function_body
+          (statements
+            (assignment
+              (directly_assignable_expression
+                (simple_identifier))
+              (integer_literal))))))))
+
+================================================================================
 Protocols
-==================
+================================================================================
 
 protocol Fallible {
     associatedtype FailureType: Error
@@ -488,55 +624,76 @@ protocol Wrapper {
     associatedtype Wrapped: Fallible where Wrapped.FailureType == NSError
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (protocol_declaration
+  (protocol_declaration
+    (type_identifier)
+    (protocol_body
+      (associatedtype_declaration
         (type_identifier)
-        (protocol_body
-            (associatedtype_declaration (type_identifier) (user_type (type_identifier)))
-            (associatedtype_declaration (type_identifier) (user_type (type_identifier)))
-            (protocol_function_declaration
+        (user_type
+          (type_identifier)))
+      (associatedtype_declaration
+        (type_identifier)
+        (user_type
+          (type_identifier)))
+      (protocol_function_declaration
+        (simple_identifier)
+        (optional_type
+          (user_type
+            (type_identifier)
+            (type_identifier)))
+        (type_constraints
+          (where_keyword)
+          (type_constraint
+            (inheritance_constraint
+              (identifier
                 (simple_identifier)
-                (optional_type (user_type (type_identifier) (type_identifier)))
-                (type_constraints
-                    (where_keyword)
-                    (type_constraint
-                        (inheritance_constraint
-                            (identifier
-                                  (simple_identifier)
-                                  (simple_identifier))
-                            (user_type (type_identifier))))))))
-    (protocol_declaration
-        (modifiers (visibility_modifier))
+                (simple_identifier))
+              (user_type
+                (type_identifier))))))))
+  (protocol_declaration
+    (modifiers
+      (visibility_modifier))
+    (type_identifier)
+    (protocol_body
+      (protocol_property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (protocol_property_requirements
+          (getter_specifier
+            (mutation_modifier))))))
+  (protocol_declaration
+    (type_identifier)
+    (protocol_body
+      (associatedtype_declaration
         (type_identifier)
-        (protocol_body
-            (protocol_property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation (user_type (type_identifier)))
-                (protocol_property_requirements (getter_specifier (mutation_modifier))))))
-    (protocol_declaration
-        (type_identifier)
-        (protocol_body
-            (associatedtype_declaration
-                (type_identifier)
-                (user_type (type_identifier))
-                (type_constraints
-                    (where_keyword)
-                    (type_constraint
-                        (equality_constraint
-                            (identifier (simple_identifier) (simple_identifier))
-                            (user_type (type_identifier)))))))))
+        (user_type
+          (type_identifier))
+        (type_constraints
+          (where_keyword)
+          (type_constraint
+            (equality_constraint
+              (identifier
+                (simple_identifier)
+                (simple_identifier))
+              (user_type
+                (type_identifier)))))))))
 
-===
+================================================================================
 Protocol with subscript
-===
+================================================================================
 
 public protocol Indexable {
     subscript(index: Int) -> T? { get }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (protocol_declaration
@@ -555,15 +712,15 @@ public protocol Indexable {
         (computed_getter
           (getter_specifier))))))
 
-===
+================================================================================
 Typealias
-===
+================================================================================
 
 class SomeClassWithAlias: NSObject {
     typealias ProtocolComposition = Protocol1 & Protocol2
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (class_declaration
@@ -579,9 +736,9 @@ class SomeClassWithAlias: NSObject {
         (user_type
           (type_identifier))))))
 
-==================
+================================================================================
 Special constructors
-==================
+================================================================================
 
 class Test {
     let a: Int
@@ -605,61 +762,116 @@ class Test {
     }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration
-        (type_identifier)
-        (class_body
-            (property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation (user_type (type_identifier))))
-            (property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation (user_type (type_identifier))))
-            (function_declaration
-                (external_parameter_name)
-                (parameter (simple_identifier) (user_type (type_identifier)))
-                (external_parameter_name)
-                (parameter (simple_identifier) (user_type (type_identifier)))
-                (function_body (statements
-                    (assignment
-                        (directly_assignable_expression
-                        (navigation_expression (self_expression) (navigation_suffix (simple_identifier))))
-                        (simple_identifier))
-                    (assignment
-                        (directly_assignable_expression
-                        (navigation_expression (self_expression) (navigation_suffix (simple_identifier))))
-                        (simple_identifier)))))
-            (function_declaration
-                (modifiers (member_modifier) (member_modifier))
-                (function_body
-                    (statements
-                        (call_expression
-                            (navigation_expression (self_expression) (navigation_suffix (simple_identifier)))
-                            (call_suffix (value_arguments (value_argument (integer_literal)) (value_argument (integer_literal))))))))
-            (function_declaration
-                (modifiers (member_modifier))
-                (parameter (simple_identifier) (user_type (type_identifier)))
-                (function_body
-                    (statements
-                        (call_expression
-                            (navigation_expression (self_expression) (navigation_suffix (simple_identifier)))
-                            (call_suffix (value_arguments (value_argument (integer_literal)) (value_argument (integer_literal))))))))
-            (function_declaration
-              (modifiers (member_modifier))
-              (bang)
-              (external_parameter_name)
-              (parameter (simple_identifier) (user_type (type_identifier)))
-              (function_body
-                (statements
-                  (call_expression
-                    (navigation_expression (self_expression) (navigation_suffix (simple_identifier)))
-                    (call_suffix (value_arguments (value_argument (simple_identifier)) (value_argument (simple_identifier)))))))))))
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier))))
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier))))
+      (function_declaration
+        (parameter
+          (simple_identifier)
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (parameter
+          (simple_identifier)
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (function_body
+          (statements
+            (assignment
+              (directly_assignable_expression
+                (navigation_expression
+                  (self_expression)
+                  (navigation_suffix
+                    (simple_identifier))))
+              (simple_identifier))
+            (assignment
+              (directly_assignable_expression
+                (navigation_expression
+                  (self_expression)
+                  (navigation_suffix
+                    (simple_identifier))))
+              (simple_identifier)))))
+      (function_declaration
+        (modifiers
+          (member_modifier)
+          (member_modifier))
+        (function_body
+          (statements
+            (call_expression
+              (navigation_expression
+                (self_expression)
+                (navigation_suffix
+                  (simple_identifier)))
+              (call_suffix
+                (value_arguments
+                  (value_argument
+                    (integer_literal))
+                  (value_argument
+                    (integer_literal))))))))
+      (function_declaration
+        (modifiers
+          (member_modifier))
+        (parameter
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (function_body
+          (statements
+            (call_expression
+              (navigation_expression
+                (self_expression)
+                (navigation_suffix
+                  (simple_identifier)))
+              (call_suffix
+                (value_arguments
+                  (value_argument
+                    (integer_literal))
+                  (value_argument
+                    (integer_literal))))))))
+      (function_declaration
+        (modifiers
+          (member_modifier))
+        (bang)
+        (parameter
+          (simple_identifier)
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (function_body
+          (statements
+            (call_expression
+              (navigation_expression
+                (self_expression)
+                (navigation_suffix
+                  (simple_identifier)))
+              (call_suffix
+                (value_arguments
+                  (value_argument
+                    (simple_identifier))
+                  (value_argument
+                    (simple_identifier)))))))))))
 
-==================
+================================================================================
 Deinit
-==================
+================================================================================
 
 class Expensive {
     deinit {
@@ -667,19 +879,25 @@ class Expensive {
     }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration
-        (type_identifier)
-        (class_body
-            (deinit_declaration
-                (function_body
-                    (statements (call_expression (simple_identifier) (call_suffix (value_arguments (value_argument (self_expression))))))))))) 
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (deinit_declaration
+        (function_body
+          (statements
+            (call_expression
+              (simple_identifier)
+              (call_suffix
+                (value_arguments
+                  (value_argument
+                    (self_expression)))))))))))
 
-==================
+================================================================================
 Enum classes
-==================
+================================================================================
 
 enum Suit {
     case diamonds
@@ -706,74 +924,110 @@ enum CStyle {
     case three = 3
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration
-        (type_identifier)
-        (enum_class_body
-            (enum_entry
-                (simple_identifier))
-            (enum_entry
-                (simple_identifier))
-            (enum_entry
-                (simple_identifier))
-            (enum_entry
-                (simple_identifier))))
-    (class_declaration
-        (type_identifier)
-        (enum_class_body
-            (property_declaration
-                (modifiers (property_modifier))
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation (user_type (type_identifier)))
-                (call_expression
-                    (prefix_expression (simple_identifier))
-                    (call_suffix (value_arguments (value_argument (line_string_literal (line_str_text)))))))
-            (enum_entry
-                (simple_identifier)
-                (enum_type_parameters (simple_identifier) (user_type (type_identifier))))
-            (enum_entry
-                (simple_identifier)
-                (enum_type_parameters (simple_identifier) (user_type (type_identifier))))
-            (enum_entry
-                (simple_identifier)
-                (enum_type_parameters (simple_identifier) (user_type (type_identifier))))
-            (enum_entry
-                (simple_identifier)
-                (simple_identifier)
-                (simple_identifier)
-                (enum_type_parameters (user_type (type_identifier))))
-            (enum_entry
-                (simple_identifier)
-                (enum_type_parameters
-                    (user_type
-                        (type_identifier)
-                        (type_arguments
-                            (user_type (type_identifier))
-                            (user_type (type_identifier))
-                            (user_type (type_identifier))))
-                    (wildcard_pattern)
-                    (simple_identifier)
-                    (dictionary_type (user_type (type_identifier)) (user_type (type_identifier))) (dictionary_literal)))
-            (function_declaration
-                (simple_identifier)
-                (function_body
-                    (statements
-                        (control_transfer_statement (line_string_literal (line_str_text))))))))
-    (class_declaration
-        (type_identifier)
-        (enum_class_body
-            (enum_entry (simple_identifier) (integer_literal))
-            (enum_entry
-                (simple_identifier) (integer_literal)
-                (simple_identifier) (integer_literal))
-            (enum_entry (simple_identifier) (integer_literal)))))
+  (class_declaration
+    (type_identifier)
+    (enum_class_body
+      (enum_entry
+        (simple_identifier))
+      (enum_entry
+        (simple_identifier))
+      (enum_entry
+        (simple_identifier))
+      (enum_entry
+        (simple_identifier))))
+  (class_declaration
+    (type_identifier)
+    (enum_class_body
+      (property_declaration
+        (modifiers
+          (property_modifier))
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (call_expression
+          (prefix_expression
+            (simple_identifier))
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (line_string_literal
+                  (line_str_text)))))))
+      (enum_entry
+        (simple_identifier)
+        (enum_type_parameters
+          (simple_identifier)
+          (user_type
+            (type_identifier))))
+      (enum_entry
+        (simple_identifier)
+        (enum_type_parameters
+          (simple_identifier)
+          (user_type
+            (type_identifier))))
+      (enum_entry
+        (simple_identifier)
+        (enum_type_parameters
+          (simple_identifier)
+          (user_type
+            (type_identifier))))
+      (enum_entry
+        (simple_identifier)
+        (simple_identifier)
+        (simple_identifier)
+        (enum_type_parameters
+          (user_type
+            (type_identifier))))
+      (enum_entry
+        (simple_identifier)
+        (enum_type_parameters
+          (user_type
+            (type_identifier)
+            (type_arguments
+              (user_type
+                (type_identifier))
+              (user_type
+                (type_identifier))
+              (user_type
+                (type_identifier))))
+          (wildcard_pattern)
+          (simple_identifier)
+          (dictionary_type
+            (user_type
+              (type_identifier))
+            (user_type
+              (type_identifier)))
+          (dictionary_literal)))
+      (function_declaration
+        (simple_identifier)
+        (function_body
+          (statements
+            (control_transfer_statement
+              (line_string_literal
+                (line_str_text))))))))
+  (class_declaration
+    (type_identifier)
+    (enum_class_body
+      (enum_entry
+        (simple_identifier)
+        (integer_literal))
+      (enum_entry
+        (simple_identifier)
+        (integer_literal)
+        (simple_identifier)
+        (integer_literal))
+      (enum_entry
+        (simple_identifier)
+        (integer_literal)))))
 
-
-==================
+================================================================================
 Extensions
-==================
+================================================================================
 
 extension Foo.Bar {
     static let baz = "1"
@@ -784,52 +1038,77 @@ extension SpecialDecorator where Self: Decorator, Self.DecoratedType == SpecialT
 
 public extension Foo where T == (arg1: Arg1, arg2: Arg2) { }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (class_declaration
-        (identifier (simple_identifier) (simple_identifier))
+  (class_declaration
+    (user_type
+      (type_identifier)
+      (type_identifier))
     (class_body
-        (property_declaration
-            (modifiers (property_modifier))
-            (value_binding_pattern (non_binding_pattern (simple_identifier)))
-            (line_string_literal (line_str_text)))
-        (property_declaration
-            (modifiers (property_modifier))
-            (value_binding_pattern (non_binding_pattern (simple_identifier)))
-            (type_annotation (user_type (type_identifier)))
-            (line_string_literal (line_str_text))))) 
-    (class_declaration
-        (identifier (simple_identifier))
-        (type_constraints
-            (where_keyword)
-            (type_constraint
-                (inheritance_constraint
-                    (identifier (simple_identifier))
-                (user_type (type_identifier))))
-            (type_constraint
-                (equality_constraint
-                    (identifier (simple_identifier) (simple_identifier))
-                    (user_type (type_identifier)))))
-        (class_body))
-    (class_declaration
-        (modifiers (visibility_modifier))
-        (identifier (simple_identifier))
-        (type_constraints
-            (where_keyword)
-            (type_constraint
-                (equality_constraint
-                    (identifier (simple_identifier))
-                    (tuple_type
-                        (simple_identifier)
-                        (user_type (type_identifier))
-                        (simple_identifier)
-                        (user_type (type_identifier))))))
-        (class_body)))
+      (property_declaration
+        (modifiers
+          (property_modifier))
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (line_string_literal
+          (line_str_text)))
+      (property_declaration
+        (modifiers
+          (property_modifier))
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier)))
+        (line_string_literal
+          (line_str_text)))))
+  (class_declaration
+    (user_type
+      (type_identifier))
+    (type_constraints
+      (where_keyword)
+      (type_constraint
+        (inheritance_constraint
+          (identifier
+            (simple_identifier))
+          (user_type
+            (type_identifier))))
+      (type_constraint
+        (equality_constraint
+          (identifier
+            (simple_identifier)
+            (simple_identifier))
+          (user_type
+            (type_identifier)))))
+    (class_body))
+  (class_declaration
+    (modifiers
+      (visibility_modifier))
+    (user_type
+      (type_identifier))
+    (type_constraints
+      (where_keyword)
+      (type_constraint
+        (equality_constraint
+          (identifier
+            (simple_identifier))
+          (tuple_type
+            (tuple_type_item
+              (simple_identifier)
+              (user_type
+                (type_identifier)))
+            (tuple_type_item
+              (simple_identifier)
+              (user_type
+                (type_identifier)))))))
+    (class_body)))
 
-============
+================================================================================
 Deprecation
-============
+================================================================================
 class Computer<T> {
     @available(*, deprecated, message: "See replacement: computeV2")
     func compute() { }
@@ -849,59 +1128,84 @@ enum ComputeType {
     case v1
 }
 
----
-(source_file
-    (class_declaration
-        (type_identifier)
-        (type_parameters (type_parameter (type_identifier)))
-        (class_body
-            (function_declaration
-                (modifiers (attribute
-                    (user_type (type_identifier))
-                    (simple_identifier)
-                    (simple_identifier)
-                    (line_string_literal (line_str_text))))
-                (simple_identifier)
-                (function_body))
-            (property_declaration
-                (modifiers (attribute
-                    (user_type (type_identifier))
-                    (simple_identifier)
-                    (simple_identifier)
-                    (line_string_literal (line_str_text))))
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (type_annotation (user_type (type_identifier))))
-            (function_declaration
-                (modifiers
-                    (attribute
-                        (user_type (type_identifier))
-                        (simple_identifier)
-                        (integer_literal) (integer_literal) (integer_literal))
-                    (attribute
-                        (user_type (type_identifier))
-                        (simple_identifier) (integer_literal) (integer_literal)
-                        (simple_identifier) (integer_literal) (integer_literal)))
-                (simple_identifier)
-                (function_body))))
-    (class_declaration
-        (type_identifier)
-        (enum_class_body
-            (enum_entry (simple_identifier))
-            (enum_entry
-                (modifiers (attribute
-                    (user_type (type_identifier))
-                    (simple_identifier)
-                    (simple_identifier)
-                    (line_string_literal (line_str_text))))
-                (simple_identifier)))))
+--------------------------------------------------------------------------------
 
-===
+(source_file
+  (class_declaration
+    (type_identifier)
+    (type_parameters
+      (type_parameter
+        (type_identifier)))
+    (class_body
+      (function_declaration
+        (modifiers
+          (attribute
+            (user_type
+              (type_identifier))
+            (simple_identifier)
+            (simple_identifier)
+            (line_string_literal
+              (line_str_text))))
+        (simple_identifier)
+        (function_body))
+      (property_declaration
+        (modifiers
+          (attribute
+            (user_type
+              (type_identifier))
+            (simple_identifier)
+            (simple_identifier)
+            (line_string_literal
+              (line_str_text))))
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (type_annotation
+          (user_type
+            (type_identifier))))
+      (function_declaration
+        (modifiers
+          (attribute
+            (user_type
+              (type_identifier))
+            (simple_identifier)
+            (integer_literal)
+            (integer_literal)
+            (integer_literal))
+          (attribute
+            (user_type
+              (type_identifier))
+            (simple_identifier)
+            (integer_literal)
+            (integer_literal)
+            (simple_identifier)
+            (integer_literal)
+            (integer_literal)))
+        (simple_identifier)
+        (function_body))))
+  (class_declaration
+    (type_identifier)
+    (enum_class_body
+      (enum_entry
+        (simple_identifier))
+      (enum_entry
+        (modifiers
+          (attribute
+            (user_type
+              (type_identifier))
+            (simple_identifier)
+            (simple_identifier)
+            (line_string_literal
+              (line_str_text))))
+        (simple_identifier)))))
+
+================================================================================
 Protocol composition - generic type specifiers
-===
+================================================================================
 
 let result: HasGeneric<P1 & P2> = HasGeneric<P1 & P2>(t: "Hello")
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
@@ -925,18 +1229,19 @@ let result: HasGeneric<P1 & P2> = HasGeneric<P1 & P2>(t: "Hello")
           (user_type
             (type_identifier))))
       (constructor_suffix
-        (value_argument
-          (simple_identifier)
-          (line_string_literal (line_str_text)))))))
+        (value_arguments
+          (value_argument
+            (simple_identifier)
+            (line_string_literal
+              (line_str_text))))))))
 
-
-===
+================================================================================
 Protocol composition - where clauses
-===
+================================================================================
 
 func iterate<S>(h: S) where S : Sequence, S.Element == P1 & P2 { }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (function_declaration
@@ -967,16 +1272,15 @@ func iterate<S>(h: S) where S : Sequence, S.Element == P1 & P2 { }
             (type_identifier)))))
     (function_body)))
 
-
-===
+================================================================================
 Protocol composition - enum declarations
-===
+================================================================================
 
 enum Foo {
   case bar(P1 & P2)
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (class_declaration
@@ -990,14 +1294,13 @@ enum Foo {
           (user_type
             (type_identifier)))))))
 
-
-===
+================================================================================
 Protocol composition in as expressions
-===
+================================================================================
 
 let result = greet("me") as P1 & P2
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
@@ -1010,15 +1313,17 @@ let result = greet("me") as P1 & P2
         (call_suffix
           (value_arguments
             (value_argument
-              (line_string_literal (line_str_text))))))
+              (line_string_literal
+                (line_str_text))))))
       (as_operator)
       (user_type
         (type_identifier))
       (user_type
         (type_identifier)))))
-===
+
+================================================================================
 Modify declarations
-===
+================================================================================
 public final class Foo {
     private var inner: T
 
@@ -1032,7 +1337,7 @@ public final class Foo {
     }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (class_declaration
@@ -1072,9 +1377,9 @@ public final class Foo {
                 (prefix_expression
                   (simple_identifier))))))))))
 
-===
+================================================================================
 Attributes on computed property declarations
-===
+================================================================================
 
 public var someVar: String {
     @inline(__always)
@@ -1083,7 +1388,7 @@ public var someVar: String {
     }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
@@ -1103,20 +1408,21 @@ public var someVar: String {
           (simple_identifier))
         (getter_specifier)
         (statements
-            (line_string_literal (line_str_text)))))))
+          (line_string_literal
+            (line_str_text)))))))
 
-===
+================================================================================
 Annotations on inheritance
-===
+================================================================================
 
 extension TrustMe: @unchecked Sendable { }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (class_declaration
-    (identifier
-      (simple_identifier))
+    (user_type
+      (type_identifier))
     (attribute
       (user_type
         (type_identifier)))
@@ -1124,4 +1430,3 @@ extension TrustMe: @unchecked Sendable { }
       (user_type
         (type_identifier)))
     (class_body)))
-

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1,91 +1,121 @@
-==================
+================================================================================
 Multiplication expression
-==================
+================================================================================
 
 45 * 3
 
----
+--------------------------------------------------------------------------------
 
-(source_file (multiplicative_expression (integer_literal) (integer_literal)))
+(source_file
+  (multiplicative_expression
+    (integer_literal)
+    (integer_literal)))
 
-==================
+================================================================================
 Subtraction expression
-==================
+================================================================================
 
 45 - 3
 
----
+--------------------------------------------------------------------------------
 
-(source_file (additive_expression (integer_literal) (integer_literal)))
+(source_file
+  (additive_expression
+    (integer_literal)
+    (integer_literal)))
 
-==================
+================================================================================
 Nil-coalescing expression
-==================
+================================================================================
 
 a ?? 0
 
----
+--------------------------------------------------------------------------------
 
-(source_file (nil_coalescing_expression (simple_identifier) (integer_literal)))
+(source_file
+  (nil_coalescing_expression
+    (simple_identifier)
+    (integer_literal)))
 
-==================
+================================================================================
 Comparison
-==================
+================================================================================
 
 a < b
 
----
+--------------------------------------------------------------------------------
 
-(source_file (comparison_expression (simple_identifier) (simple_identifier)))
+(source_file
+  (comparison_expression
+    (simple_identifier)
+    (simple_identifier)))
 
-==================
+================================================================================
 Conjunction
-==================
+================================================================================
 
 a && b
 
 a
     && b
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (conjunction_expression (simple_identifier) (simple_identifier))
-    (conjunction_expression (simple_identifier) (simple_identifier)))
+  (conjunction_expression
+    (simple_identifier)
+    (simple_identifier))
+  (conjunction_expression
+    (simple_identifier)
+    (simple_identifier)))
 
-==================
+================================================================================
 Bitwise operations
-==================
+================================================================================
 
 a & b
 a | b
 a << b
 a >> b
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (bitwise_operation (simple_identifier) (simple_identifier))
-    (bitwise_operation (simple_identifier) (simple_identifier))
-    (bitwise_operation (simple_identifier) (simple_identifier))
-    (bitwise_operation (simple_identifier) (simple_identifier))) 
+  (bitwise_operation
+    (simple_identifier)
+    (simple_identifier))
+  (bitwise_operation
+    (simple_identifier)
+    (simple_identifier))
+  (bitwise_operation
+    (simple_identifier)
+    (simple_identifier))
+  (bitwise_operation
+    (simple_identifier)
+    (simple_identifier)))
 
-==================
+================================================================================
 Tuple access operator
-==================
+================================================================================
 
 event.0
 possibleEvent?.0
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (navigation_expression (simple_identifier) (navigation_suffix (integer_literal)))
-    (navigation_expression (simple_identifier) (navigation_suffix (integer_literal))))
+  (navigation_expression
+    (simple_identifier)
+    (navigation_suffix
+      (integer_literal)))
+  (navigation_expression
+    (simple_identifier)
+    (navigation_suffix
+      (integer_literal))))
 
-==================
+================================================================================
 Ternary expression
-==================
+================================================================================
 
 a ? b : c
 
@@ -93,26 +123,32 @@ someVeryLongFunctionCall()
     ? doSomethingHere()
     : fallback
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (ternary_expression (simple_identifier) (simple_identifier) (simple_identifier))
-    (ternary_expression
-        (call_expression
-            (simple_identifier)
-            (call_suffix (value_arguments)))
-        (call_expression
-            (simple_identifier)
-            (call_suffix (value_arguments)))
-        (simple_identifier)))
-===
+  (ternary_expression
+    (simple_identifier)
+    (simple_identifier)
+    (simple_identifier))
+  (ternary_expression
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (simple_identifier)))
+
+================================================================================
 Ternary within another expression
-===
+================================================================================
 
 if a ? b : c == d {
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (if_statement
@@ -123,13 +159,13 @@ if a ? b : c == d {
         (simple_identifier)
         (simple_identifier)))))
 
-===
+================================================================================
 Ternary with a function at the end
-===
+================================================================================
 
 foo() ? bar() : baz()
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (ternary_expression
@@ -146,27 +182,27 @@ foo() ? bar() : baz()
       (call_suffix
         (value_arguments)))))
 
-==================
+================================================================================
 Multiple expressions on one line using semicolons
-==================
+================================================================================
 
 print(a); throw b
 
----
+--------------------------------------------------------------------------------
 
-    (source_file
-      (call_expression
-        (simple_identifier)
-        (call_suffix
-          (value_arguments
-            (value_argument
-              (simple_identifier)))))
-      (throw_keyword)
-      (simple_identifier))
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (simple_identifier)))))
+  (throw_keyword)
+  (simple_identifier))
 
-==================
+================================================================================
 Indexing
-==================
+================================================================================
 
 let b = maybeNil?[2]
 a[2] = b
@@ -174,192 +210,265 @@ let c = array[safe: index]
 let d = weirdType[indexesByField, and: anotherField]
 let e = array[...]
 
----
+--------------------------------------------------------------------------------
 
- (source_file
-    (property_declaration
-        (value_binding_pattern
-            (non_binding_pattern (simple_identifier)))
-        (call_expression (simple_identifier) (call_suffix (value_arguments (value_argument (integer_literal))))))
-    (assignment
-        (directly_assignable_expression
-            (call_expression (simple_identifier) (call_suffix (value_arguments (value_argument (integer_literal))))))
-        (simple_identifier))
-    (property_declaration
-        (value_binding_pattern
-            (non_binding_pattern (simple_identifier)))
-        (call_expression
+(source_file
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (integer_literal))))))
+  (assignment
+    (directly_assignable_expression
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments
+            (value_argument
+              (integer_literal))))))
+    (simple_identifier))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments
+          (value_argument
             (simple_identifier)
-                (call_suffix (value_arguments (value_argument (simple_identifier) (simple_identifier))))))
-    (property_declaration
-        (value_binding_pattern
-            (non_binding_pattern (simple_identifier)))
-        (call_expression
+            (simple_identifier))))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (simple_identifier))
+          (value_argument
             (simple_identifier)
-            (call_suffix
-                (value_arguments
-                    (value_argument (simple_identifier))
-                    (value_argument (simple_identifier) (simple_identifier))))))
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (call_expression
-            (simple_identifier)
-            (call_suffix
-                (value_arguments
-                    (value_argument (fully_open_range)))))))
+            (simple_identifier))))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (fully_open_range)))))))
 
-==================
+================================================================================
 Assigning to self
-==================
+================================================================================
 
 self = .enumCase
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (assignment
-        (directly_assignable_expression (self_expression))
-        (prefix_expression (simple_identifier))))
+  (assignment
+    (directly_assignable_expression
+      (self_expression))
+    (prefix_expression
+      (simple_identifier))))
 
-==================
+================================================================================
 Assignment
-==================
+================================================================================
 
 let one = 1
 var two: Int = 2
 _ = someCall()
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (integer_literal))
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (type_annotation (user_type (type_identifier)))
-        (integer_literal))
-    (assignment
-        (directly_assignable_expression (simple_identifier))
-        (call_expression (simple_identifier) (call_suffix (value_arguments)))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (integer_literal))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (type_annotation
+      (user_type
+        (type_identifier)))
+    (integer_literal))
+  (assignment
+    (directly_assignable_expression
+      (simple_identifier))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))))
 
-==================
+================================================================================
 Destructuring assignment
-==================
+================================================================================
 
 (lhs, rhs) = someOperation
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (assignment
-        (directly_assignable_expression (tuple_expression (simple_identifier) (simple_identifier)))
+  (assignment
+    (directly_assignable_expression
+      (tuple_expression
+        (simple_identifier)
         (simple_identifier)))
+    (simple_identifier)))
 
-==================
+================================================================================
 Implicit member expression
-==================
+================================================================================
 
 let a: SomeClass = .someInstance
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (type_annotation (user_type (type_identifier)))
-        (prefix_expression (simple_identifier))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (type_annotation
+      (user_type
+        (type_identifier)))
+    (prefix_expression
+      (simple_identifier))))
 
-==================
+================================================================================
 Tuple expressions
-==================
+================================================================================
 
 func math() {
     let a: (Int, Int) = (1, 2)
     return (lhs: 3, rhs: 4)
 }
 
----
+--------------------------------------------------------------------------------
 
-    (source_file
-      (function_declaration
-        (simple_identifier)
-        (function_body
-          (statements
-            (property_declaration
-              (value_binding_pattern
-                (non_binding_pattern
-                  (simple_identifier)))
-              (type_annotation
-                (tuple_type
-                  (user_type
-                    (type_identifier))
-                  (user_type
-                    (type_identifier))))
-              (tuple_expression
-                (integer_literal)
-                (integer_literal)))
-            (control_transfer_statement
-              (tuple_expression
-                (simple_identifier)
-                (integer_literal)
-                (simple_identifier)
-                (integer_literal)))))))
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_body
+      (statements
+        (property_declaration
+          (value_binding_pattern
+            (non_binding_pattern
+              (simple_identifier)))
+          (type_annotation
+            (tuple_type
+              (tuple_type_item
+                (user_type
+                  (type_identifier)))
+              (tuple_type_item
+                (user_type
+                  (type_identifier)))))
+          (tuple_expression
+            (integer_literal)
+            (integer_literal)))
+        (control_transfer_statement
+          (tuple_expression
+            (simple_identifier)
+            (integer_literal)
+            (simple_identifier)
+            (integer_literal)))))))
 
-==================
+================================================================================
 Function calls
-==================
+================================================================================
 
 print("Hello World!")
 sum(1, 2)
 something.hello?("world")
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (call_expression (simple_identifier)
-        (call_suffix (value_arguments
-            (value_argument (line_string_literal (line_str_text))))))
-    (call_expression (simple_identifier)
-        (call_suffix (value_arguments
-            (value_argument (integer_literal))
-            (value_argument (integer_literal)))))
-    (call_expression
-        (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
-        (call_suffix (value_arguments (value_argument (line_string_literal (line_str_text)))))))
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (line_string_literal
+            (line_str_text))))))
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (integer_literal))
+        (value_argument
+          (integer_literal)))))
+  (call_expression
+    (navigation_expression
+      (simple_identifier)
+      (navigation_suffix
+        (simple_identifier)))
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (line_string_literal
+            (line_str_text)))))))
 
-==================
+================================================================================
 Constructor calls
-==================
+================================================================================
 
 var result = Set<String>()
 var result2 = [String: [Complex<[String: Any]>]]()
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (constructor_expression
-            (user_type (type_identifier) (type_arguments (user_type (type_identifier))))
-            (constructor_suffix)))
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (constructor_expression
-            (dictionary_type
-                (user_type (type_identifier))
-                (array_type
-                    (user_type
-                        (type_identifier)
-                        (type_arguments
-                            (dictionary_type
-                                (user_type (type_identifier))
-                                (user_type (type_identifier)))))))
-            (constructor_suffix))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (constructor_expression
+      (user_type
+        (type_identifier)
+        (type_arguments
+          (user_type
+            (type_identifier))))
+      (constructor_suffix
+        (value_arguments))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (constructor_expression
+      (dictionary_type
+        (user_type
+          (type_identifier))
+        (array_type
+          (user_type
+            (type_identifier)
+            (type_arguments
+              (dictionary_type
+                (user_type
+                  (type_identifier))
+                (user_type
+                  (type_identifier)))))))
+      (constructor_suffix
+        (value_arguments)))))
 
-==================
+================================================================================
 Inout functions
-==================
+================================================================================
 
 func modifyThis(_ toModify: inout [String: String]) {
 }
@@ -367,136 +476,191 @@ func modifyThis(_ toModify: inout [String: String]) {
 var this = [:]
 modifyThis(&this)
 
----
+--------------------------------------------------------------------------------
+
 (source_file
-    (function_declaration
-        (simple_identifier)
-        (external_parameter_name)
-        (parameter (simple_identifier)
-            (parameter_modifiers (parameter_modifier))
-            (dictionary_type (user_type (type_identifier)) (user_type (type_identifier))))
-        (function_body))
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (dictionary_literal))
-    (call_expression
-        (simple_identifier)
-        (call_suffix (value_arguments (value_argument (prefix_expression (simple_identifier)))))))
+  (function_declaration
+    (simple_identifier)
+    (parameter
+      (simple_identifier)
+      (simple_identifier)
+      (parameter_modifiers
+        (parameter_modifier))
+      (dictionary_type
+        (user_type
+          (type_identifier))
+        (user_type
+          (type_identifier))))
+    (function_body))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (dictionary_literal))
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (prefix_expression
+            (simple_identifier)))))))
 
-
-==================
+================================================================================
 Selectors
-==================
+================================================================================
 
 let selector = #selector(self.foo(parameter:))
 let getterSelector = #selector(getter: self.bar)
 let setterSelector = #selector(setter: self.bar)
 
----
-(source_file
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (selector_expression
-            (call_expression
-                (navigation_expression
-                (self_expression)
-                (navigation_suffix (simple_identifier)))
-                (call_suffix (value_arguments (value_argument (simple_identifier)))))))
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (selector_expression (navigation_expression (self_expression) (navigation_suffix (simple_identifier)))))
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (selector_expression (navigation_expression (self_expression) (navigation_suffix (simple_identifier))))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (selector_expression
+      (call_expression
+        (navigation_expression
+          (self_expression)
+          (navigation_suffix
+            (simple_identifier)))
+        (call_suffix
+          (value_arguments
+            (value_argument
+              (simple_identifier)))))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (selector_expression
+      (navigation_expression
+        (self_expression)
+        (navigation_suffix
+          (simple_identifier)))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (selector_expression
+      (navigation_expression
+        (self_expression)
+        (navigation_suffix
+          (simple_identifier))))))
+
+================================================================================
 Function references
-==================
+================================================================================
 
 self.foo(parameter:)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (call_expression
-        (navigation_expression
-            (self_expression)
-            (navigation_suffix (simple_identifier)))
-        (call_suffix (value_arguments (value_argument (simple_identifier))))))
+  (call_expression
+    (navigation_expression
+      (self_expression)
+      (navigation_suffix
+        (simple_identifier)))
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (simple_identifier))))))
 
-======
+================================================================================
 Complex ternary expression
-======
+================================================================================
 
 let availableRules = (context == nil) ? [.noContextRule] : []
 let result: MyEnumType = condition ? .someEnumCase : .someOtherEnum
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (ternary_expression
-            (tuple_expression (equality_expression (simple_identifier)))
-            (array_literal (prefix_expression (simple_identifier)))
-            (array_literal)))
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (type_annotation (user_type (type_identifier)))
-        (ternary_expression
-            (simple_identifier)
-            (prefix_expression (simple_identifier))
-            (prefix_expression (simple_identifier)))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (ternary_expression
+      (tuple_expression
+        (equality_expression
+          (simple_identifier)))
+      (array_literal
+        (prefix_expression
+          (simple_identifier)))
+      (array_literal)))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (type_annotation
+      (user_type
+        (type_identifier)))
+    (ternary_expression
+      (simple_identifier)
+      (prefix_expression
+        (simple_identifier))
+      (prefix_expression
+        (simple_identifier)))))
 
-======
+================================================================================
 Range expression in indexing
-======
+================================================================================
 
 string[..<string.index(before: string.endIndex)]
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (call_expression
-        (simple_identifier)
-        (call_suffix
-            (value_arguments
-                (value_argument
-                    (open_start_range_expression
-                        (call_expression
-                            (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
-                            (call_suffix
-                                (value_arguments
-                                    (value_argument
-                                        (simple_identifier)
-                                        (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))))))))))))
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (open_start_range_expression
+            (call_expression
+              (navigation_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier)))
+              (call_suffix
+                (value_arguments
+                  (value_argument
+                    (simple_identifier)
+                    (navigation_expression
+                      (simple_identifier)
+                      (navigation_suffix
+                        (simple_identifier)))))))))))))
 
-======
+================================================================================
 Range expression in loop
-======
+================================================================================
 
 for i in 0 ..< something.count {
     // Do something
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (for_statement
+  (for_statement
+    (simple_identifier)
+    (range_expression
+      (integer_literal)
+      (navigation_expression
         (simple_identifier)
-        (range_expression
-            (integer_literal)
-            (navigation_expression (simple_identifier)
-                (navigation_suffix (simple_identifier))))
-            (comment)))
+        (navigation_suffix
+          (simple_identifier))))
+    (comment)))
 
-===
+================================================================================
 Range with force unwrapped contents
-===
+================================================================================
 
 _ = contents[Int(prefix)!...]
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (assignment
@@ -517,32 +681,41 @@ _ = contents[Int(prefix)!...]
                         (simple_identifier)))))
                 (bang)))))))))
 
-
-============
+================================================================================
 Split nullable navigation expression
-============
+================================================================================
 
 foo.doSomething(a)?
     .andThen(b)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (call_expression
+  (call_expression
+    (navigation_expression
+      (call_expression
         (navigation_expression
-            (call_expression
-                (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
-                (call_suffix (value_arguments (value_argument (simple_identifier)))))
-            (navigation_suffix (simple_identifier)))
-        (call_suffix (value_arguments (value_argument (simple_identifier))))))
+          (simple_identifier)
+          (navigation_suffix
+            (simple_identifier)))
+        (call_suffix
+          (value_arguments
+            (value_argument
+              (simple_identifier)))))
+      (navigation_suffix
+        (simple_identifier)))
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (simple_identifier))))))
 
-===
+================================================================================
 Property wrapper projections
-===
+================================================================================
 
 Image.url(url, isLoaded: $done)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (call_expression
@@ -558,9 +731,9 @@ Image.url(url, isLoaded: $done)
           (simple_identifier)
           (simple_identifier))))))
 
-===
+================================================================================
 Key-path expressions
-===
+================================================================================
 
 let pathToProperty = \SomeStructure.someValue
 
@@ -575,7 +748,7 @@ let nestedKeyPath = \OuterStructure.outer.someValue
 
 let keyPathStringExpression = #keyPath(someProperty)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
@@ -615,8 +788,10 @@ let keyPathStringExpression = #keyPath(someProperty)
       (lambda_literal
         (lambda_function_type
           (lambda_function_type_parameters
-            (simple_identifier)
-            (simple_identifier)))
+            (lambda_parameter
+              (simple_identifier))
+            (lambda_parameter
+              (simple_identifier))))
         (comment))))
   (assignment
     (directly_assignable_expression
@@ -647,20 +822,20 @@ let keyPathStringExpression = #keyPath(someProperty)
           (simple_identifier)))
       (navigation_suffix
         (simple_identifier))))
-      (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
-        (key_path_string_expression
-          (simple_identifier))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (key_path_string_expression
+      (simple_identifier))))
 
-===
+================================================================================
 Tuple expression in function
-===
+================================================================================
 
 trimPathAtLengths(positions: [(start: start, end: end)])
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (call_expression
@@ -676,14 +851,14 @@ trimPathAtLengths(positions: [(start: start, end: end)])
               (simple_identifier)
               (simple_identifier))))))))
 
-===
+================================================================================
 Navigation expressions
-===
+================================================================================
 
 _ = self.foo.bar.baz
 print(thing.maybeGreeting!.definitely)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (assignment
@@ -708,19 +883,19 @@ print(thing.maybeGreeting!.definitely)
             (postfix_expression
               (navigation_expression
                 (simple_identifier)
-              (navigation_suffix
-                (simple_identifier)))
+                (navigation_suffix
+                  (simple_identifier)))
               (bang))
             (navigation_suffix
               (simple_identifier))))))))
 
-===
+================================================================================
 Check expression
-===
+================================================================================
 
 checkThat(dict is Dictionary<Foo, Bar>)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (call_expression
@@ -738,13 +913,13 @@ checkThat(dict is Dictionary<Foo, Bar>)
                 (user_type
                   (type_identifier))))))))))
 
-===
+================================================================================
 Navigation expression involving explicit type parameters
-===
+================================================================================
 
 SignalProducer<(), CarthageError>.empty
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (navigation_expression
@@ -757,9 +932,9 @@ SignalProducer<(), CarthageError>.empty
     (navigation_suffix
       (simple_identifier))))
 
-===
+================================================================================
 Suppressing the syntactic significance of a newline
-===
+================================================================================
 
 let _ = (1+2)
     / 3
@@ -771,7 +946,7 @@ let two = 2
     + 2
     - 2
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
@@ -793,24 +968,24 @@ let two = 2
         (additive_expression
           (integer_literal)
           (integer_literal)))
-          (integer_literal)))
-      (property_declaration
-        (value_binding_pattern
-          (non_binding_pattern
-            (simple_identifier)))
-        (additive_expression
-          (additive_expression
-            (integer_literal)
-            (integer_literal))
-        (integer_literal))))
+      (integer_literal)))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (additive_expression
+      (additive_expression
+        (integer_literal)
+        (integer_literal))
+      (integer_literal))))
 
-===
+================================================================================
 Simple try
-===
+================================================================================
 
 try foo()
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (try_expression
@@ -819,28 +994,31 @@ try foo()
       (call_suffix
         (value_arguments)))))
 
-===
+================================================================================
 Try and ternary
-===
+================================================================================
 
 try foo() ? 1 : 0
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (try_expression
     (ternary_expression
-      (call_expression (simple_identifier) (call_suffix (value_arguments)))
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments)))
       (integer_literal)
       (integer_literal))))
 
-===
+================================================================================
 Simple await
-===
+================================================================================
 
 await foo()
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (await_expression
@@ -849,14 +1027,14 @@ await foo()
       (call_suffix
         (value_arguments)))))
 
-===
+================================================================================
 try await
-===
+================================================================================
 
 try await foo()
 await try foo()
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (try_expression
@@ -872,31 +1050,33 @@ await try foo()
         (call_suffix
           (value_arguments))))))
 
-
-===
+================================================================================
 Await and ternary
-===
+================================================================================
 
 await foo() ? 1 : 0
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (await_expression
     (ternary_expression
-      (call_expression (simple_identifier) (call_suffix (value_arguments)))
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments)))
       (integer_literal)
       (integer_literal))))
 
-===
+================================================================================
 for try await
-===
+================================================================================
 
 for try await value in values {
     print(value)
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (for_statement
@@ -910,16 +1090,16 @@ for try await value in values {
             (value_argument
               (simple_identifier))))))))
 
-===
+================================================================================
 Negation at the start of a line
-===
+================================================================================
 
 
 let a = false
 
 !a
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -1,54 +1,67 @@
-==================
+================================================================================
 Top-level functions
-==================
+================================================================================
 
 func main() {}
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (function_declaration
-        (simple_identifier)
-        (function_body)))
+  (function_declaration
+    (simple_identifier)
+    (function_body)))
 
-==================
+================================================================================
 Generic functions
-==================
+================================================================================
 
 func test<T>(t: T) {}
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (function_declaration
-        (simple_identifier)
-        (type_parameters (type_parameter (type_identifier)))
-        (parameter (simple_identifier) (user_type (type_identifier)))
-        (function_body)))
+  (function_declaration
+    (simple_identifier)
+    (type_parameters
+      (type_parameter
+        (type_identifier)))
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (function_body)))
 
-==================
+================================================================================
 Static functions
-==================
+================================================================================
 
 static func help() {}
 static func === (lhs: MyType, rhs: MyType) { }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (function_declaration
-        (modifiers (property_modifier))
-        (simple_identifier)
-        (function_body))
-    (function_declaration
-        (modifiers (property_modifier))
-        (parameter (simple_identifier) (user_type (type_identifier)))
-        (parameter (simple_identifier) (user_type (type_identifier)))
-        (function_body)))
+  (function_declaration
+    (modifiers
+      (property_modifier))
+    (simple_identifier)
+    (function_body))
+  (function_declaration
+    (modifiers
+      (property_modifier))
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (function_body)))
 
-==================
+================================================================================
 Functions with parameters
-==================
+================================================================================
 
 func main(args: [String]) {}
 
@@ -58,80 +71,99 @@ func convert(@Arg args: [String: Int]) {}
 
 func sum(a: Int, b: Int!) { return a + b }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (function_declaration
-        (simple_identifier)
-        (parameter 
+  (function_declaration
+    (simple_identifier)
+    (parameter
+      (simple_identifier)
+      (array_type
+        (user_type
+          (type_identifier))))
+    (function_body))
+  (function_declaration
+    (simple_identifier)
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)
+        (type_arguments
+          (user_type
+            (type_identifier)))))
+    (function_body))
+  (function_declaration
+    (simple_identifier)
+    (attribute
+      (user_type
+        (type_identifier)))
+    (parameter
+      (simple_identifier)
+      (dictionary_type
+        (user_type
+          (type_identifier))
+        (user_type
+          (type_identifier))))
+    (function_body))
+  (function_declaration
+    (simple_identifier)
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (additive_expression
             (simple_identifier)
-            (array_type (user_type (type_identifier))))
-        (function_body))
-    (function_declaration
-        (simple_identifier)
-        (parameter 
-            (simple_identifier)
-            (user_type
-                (type_identifier)
-                (type_arguments (user_type (type_identifier)))))
-        (function_body))
-    (function_declaration
-        (simple_identifier)
-        (attribute (user_type (type_identifier)))
-        (parameter 
-            (simple_identifier)
-            (dictionary_type (user_type (type_identifier)) (user_type (type_identifier))))
-        (function_body))
-    (function_declaration
-        (simple_identifier)
-        (parameter
-            (simple_identifier)
-            (user_type (type_identifier)))
-        (parameter
-            (simple_identifier)
-            (user_type (type_identifier)))
-        (function_body
-            (statements
-                (control_transfer_statement
-                    (additive_expression
-                        (simple_identifier) (simple_identifier)))))))
+            (simple_identifier)))))))
 
-==================
+================================================================================
 Functions with renamed parameters
-==================
+================================================================================
 
 func sum(_ a: Int, with b: Int) { return a + b }
 
 sum(1, with: 2)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (function_declaration
-        (simple_identifier)
-        (external_parameter_name)
-        (parameter
+  (function_declaration
+    (simple_identifier)
+    (parameter
+      (simple_identifier)
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (parameter
+      (simple_identifier)
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (additive_expression
             (simple_identifier)
-            (user_type (type_identifier)))
-        (external_parameter_name)
-        (parameter
-            (simple_identifier)
-            (user_type (type_identifier)))
-        (function_body
-            (statements
-                (control_transfer_statement
-                    (additive_expression
-                        (simple_identifier) (simple_identifier))))))
-     (call_expression
-        (simple_identifier)
-            (call_suffix
-                (value_arguments
-                    (value_argument (integer_literal))
-                    (value_argument (simple_identifier) (integer_literal))))))
+            (simple_identifier))))))
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (integer_literal))
+        (value_argument
+          (simple_identifier)
+          (integer_literal))))))
 
-==================
+================================================================================
 Functions with return types
-==================
+================================================================================
 
 func answerToTheUltimateQuestionOfLifeTheUniverseAndEverything() -> Int { return 42 }
 func getConfig() -> [String: Int] {
@@ -146,49 +178,68 @@ func returnGetsImplicitlyUnwrapped() -> String! {
     return nil
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (function_declaration
-        (simple_identifier)
-        (user_type (type_identifier))
-        (function_body
-            (statements
-                (control_transfer_statement
-                    (integer_literal)))))
-    (function_declaration
-        (simple_identifier)
-        (dictionary_type (user_type (type_identifier)) (user_type (type_identifier)))
-        (function_body
-            (statements
-                (control_transfer_statement
-                    (dictionary_literal
-                        (line_string_literal (line_str_text)) (integer_literal)
-                        (line_string_literal (line_str_text)) (integer_literal)
-                        (line_string_literal (line_str_text)) (integer_literal))))))
-    (function_declaration
-        (simple_identifier)
-        (user_type (type_identifier))
-        (function_body (statements (control_transfer_statement)))))
+  (function_declaration
+    (simple_identifier)
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (integer_literal)))))
+  (function_declaration
+    (simple_identifier)
+    (dictionary_type
+      (user_type
+        (type_identifier))
+      (user_type
+        (type_identifier)))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (dictionary_literal
+            (line_string_literal
+              (line_str_text))
+            (integer_literal)
+            (line_string_literal
+              (line_str_text))
+            (integer_literal)
+            (line_string_literal
+              (line_str_text))
+            (integer_literal))))))
+  (function_declaration
+    (simple_identifier)
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (control_transfer_statement)))))
 
-==================
+================================================================================
 Variadic functions
-==================
+================================================================================
 
 func toUpperCaseAll(strings: String ...) -> [String] { }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (function_declaration
-        (simple_identifier)
-        (parameter (simple_identifier) (user_type (type_identifier)))
-        (array_type (user_type (type_identifier)))
-        (function_body)))
+  (function_declaration
+    (simple_identifier)
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (array_type
+      (user_type
+        (type_identifier)))
+    (function_body)))
 
-=================
+================================================================================
 Operator overrides
-=================
+================================================================================
 
 public static func < (lhs: Wrapped<F>, rhs: Wrapped<F>) -> Bool {
     return false 
@@ -202,63 +253,98 @@ public prefix func ! (value: Wrapped<F>) -> Bool {
     return false
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (function_declaration
-        (modifiers (visibility_modifier) (property_modifier))
-        (parameter (simple_identifier) (user_type (type_identifier) (type_arguments (user_type (type_identifier)))))
-        (parameter (simple_identifier) (user_type (type_identifier) (type_arguments (user_type (type_identifier)))))
-        (user_type (type_identifier))
-        (function_body
-            (statements
-                (control_transfer_statement (boolean_literal)))))
-    (function_declaration
-        (modifiers (visibility_modifier))
-        (custom_operator)
-        (type_parameters
-            (type_parameter
-                (type_identifier)
-                (user_type (type_identifier))))
-        (parameter
-            (simple_identifier)
-            (user_type
-                (type_identifier)
-                (type_arguments (optional_type (user_type (type_identifier))))))
-        (parameter (simple_identifier) (user_type (type_identifier)))
-        (user_type (type_identifier) (type_arguments (user_type (type_identifier))))
-        (function_body
-            (statements
-                (control_transfer_statement
-                    (call_expression (simple_identifier)
-                        (call_suffix
-                            (value_arguments
-                                (value_argument
-                                    (nil_coalescing_expression
-                                        (call_expression
-                                            (navigation_expression
-                                                (simple_identifier)
-                                                (navigation_suffix (simple_identifier)))
-                                            (call_suffix (value_arguments)))
-                                        (simple_identifier))))))))))
-      (function_declaration
-        (modifiers (visibility_modifier) (function_modifier))
-        (bang)
-        (parameter
-          (simple_identifier)
+  (function_declaration
+    (modifiers
+      (visibility_modifier)
+      (property_modifier))
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)
+        (type_arguments
           (user_type
-            (type_identifier)
-            (type_arguments (user_type (type_identifier)))))
-        (user_type (type_identifier))
-        (function_body
-          (statements
-            (control_transfer_statement
-              (boolean_literal))))))
+            (type_identifier)))))
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)
+        (type_arguments
+          (user_type
+            (type_identifier)))))
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (boolean_literal)))))
+  (function_declaration
+    (modifiers
+      (visibility_modifier))
+    (custom_operator)
+    (type_parameters
+      (type_parameter
+        (type_identifier)
+        (user_type
+          (type_identifier))))
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)
+        (type_arguments
+          (optional_type
+            (user_type
+              (type_identifier))))))
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (user_type
+      (type_identifier)
+      (type_arguments
+        (user_type
+          (type_identifier))))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments
+                (value_argument
+                  (nil_coalescing_expression
+                    (call_expression
+                      (navigation_expression
+                        (simple_identifier)
+                        (navigation_suffix
+                          (simple_identifier)))
+                      (call_suffix
+                        (value_arguments)))
+                    (simple_identifier))))))))))
+  (function_declaration
+    (modifiers
+      (visibility_modifier)
+      (function_modifier))
+    (bang)
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)
+        (type_arguments
+          (user_type
+            (type_identifier)))))
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (boolean_literal))))))
 
-
-==================
+================================================================================
 Custom operators
-==================
+================================================================================
 
 precedencegroup MyPrecedence {
     associativity: left
@@ -268,24 +354,32 @@ precedencegroup MyPrecedence {
 
 infix operator -=- : MyPrecedence
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (precedence_group_declaration
+  (precedence_group_declaration
+    (simple_identifier)
+    (precedence_group_attributes
+      (precedence_group_attribute
         (simple_identifier)
-        (precedence_group_attributes
-            (precedence_group_attribute (simple_identifier) (simple_identifier))
-            (precedence_group_attribute (simple_identifier) (boolean_literal))
-            (precedence_group_attribute (simple_identifier) (simple_identifier))))
-    (operator_declaration (custom_operator) (simple_identifier)))
+        (simple_identifier))
+      (precedence_group_attribute
+        (simple_identifier)
+        (boolean_literal))
+      (precedence_group_attribute
+        (simple_identifier)
+        (simple_identifier))))
+  (operator_declaration
+    (custom_operator)
+    (simple_identifier)))
 
-===
+================================================================================
 Custom operator with another operator as a prefix
-===
+================================================================================
 
 let messageCoerced = error ??? "nil"
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
@@ -295,39 +389,45 @@ let messageCoerced = error ??? "nil"
     (infix_expression
       (simple_identifier)
       (custom_operator)
-      (line_string_literal (line_str_text)))))
+      (line_string_literal
+        (line_str_text)))))
 
-==================
+================================================================================
 Functions that throw
-==================
+================================================================================
 
 func anythingYouCanDo() throws -> Int { return -1 }
 func iCanDoBetter()
     throws
     -> Int { return -2 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (function_declaration
-        (simple_identifier)
-                (throws)
-        (user_type (type_identifier))
-        (function_body
-            (statements
-                (control_transfer_statement (prefix_expression (integer_literal))))))
-    (function_declaration
-        (simple_identifier)
-        (throws)
-        (user_type (type_identifier))
-        (function_body
-            (statements
-                (control_transfer_statement (prefix_expression (integer_literal)))))))
+  (function_declaration
+    (simple_identifier)
+    (throws)
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (prefix_expression
+            (integer_literal))))))
+  (function_declaration
+    (simple_identifier)
+    (throws)
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (prefix_expression
+            (integer_literal)))))))
 
-
-==================
+================================================================================
 Async functions
-==================
+================================================================================
 
 func eventually() async -> Int { return -1 }
 func maybe()
@@ -335,278 +435,361 @@ func maybe()
     throws
     -> Int { return -2 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (function_declaration
-        (simple_identifier)
-                (async)
-        (user_type (type_identifier))
-        (function_body
-            (statements
-                (control_transfer_statement (prefix_expression (integer_literal))))))
-    (function_declaration
-        (simple_identifier)
-        (async)
-        (throws)
-        (user_type (type_identifier))
-        (function_body
-            (statements
-                (control_transfer_statement (prefix_expression (integer_literal)))))))
+  (function_declaration
+    (simple_identifier)
+    (async)
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (prefix_expression
+            (integer_literal))))))
+  (function_declaration
+    (simple_identifier)
+    (async)
+    (throws)
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (prefix_expression
+            (integer_literal)))))))
 
-
-==================
+================================================================================
 Higher-order functions - pt 1
-==================
+================================================================================
 
 func test(i: Int = 0, block: (Int) throws -> Void) {}
 
----
+--------------------------------------------------------------------------------
+
 (source_file
-    (function_declaration
-        (simple_identifier)
-        (parameter (simple_identifier)
-            (user_type (type_identifier)))
-        (integer_literal)
-        (parameter (simple_identifier)
-            (function_type
-            (tuple_type
-                (user_type (type_identifier)))
-            (throws)
-            (user_type (type_identifier))))
-        (function_body)))
+  (function_declaration
+    (simple_identifier)
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (integer_literal)
+    (parameter
+      (simple_identifier)
+      (function_type
+        (tuple_type
+          (tuple_type_item
+            (user_type
+              (type_identifier))))
+        (throws)
+        (user_type
+          (type_identifier))))
+    (function_body)))
 
-
-==================
+================================================================================
 Higher-order functions - pt 2
-==================
+================================================================================
 
 test { value in /* does nothing */ }
 
----
+--------------------------------------------------------------------------------
+
 (source_file
-    (call_expression
-        (simple_identifier)
-        (call_suffix
-            (lambda_literal
-                (lambda_function_type
-                    (lambda_function_type_parameters (simple_identifier)))
-                (multiline_comment)))))
-==================
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (lambda_literal
+        (lambda_function_type
+          (lambda_function_type_parameters
+            (lambda_parameter
+              (simple_identifier))))
+        (multiline_comment)))))
+
+================================================================================
 Higher-order functions - pt 3
-==================
+================================================================================
 
 test(2) { $0.doSomething() }
 
----
+--------------------------------------------------------------------------------
+
 (source_file
+  (call_expression
     (call_expression
-        (call_expression
-            (simple_identifier)
-            (call_suffix (value_arguments (value_argument (integer_literal)))))
-        (call_suffix
-            (lambda_literal
-                (statements
-                    (call_expression
-                        (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
-                        (call_suffix (value_arguments))))))))
-==================
+      (simple_identifier)
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (integer_literal)))))
+    (call_suffix
+      (lambda_literal
+        (statements
+          (call_expression
+            (navigation_expression
+              (simple_identifier)
+              (navigation_suffix
+                (simple_identifier)))
+            (call_suffix
+              (value_arguments))))))))
+
+================================================================================
 Higher-order functions - pt 4
-==================
+================================================================================
 
 test { (a) -> Void in }
 
----
-(source_file
-    (call_expression
-        (simple_identifier)
-        (call_suffix
-            (lambda_literal
-                (lambda_function_type
-                    (lambda_function_type_parameters (simple_identifier))
-                    (user_type (type_identifier)))))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (lambda_literal
+        (lambda_function_type
+          (lambda_function_type_parameters
+            (lambda_parameter
+              (simple_identifier)))
+          (user_type
+            (type_identifier)))))))
+
+================================================================================
 Higher-order functions - pt 5
-==================
+================================================================================
 
 test { (a: inout Int) in }
 
----
-(source_file
-    (call_expression
-        (simple_identifier)
-        (call_suffix
-            (lambda_literal
-                (lambda_function_type
-                    (lambda_function_type_parameters (simple_identifier)
-                        (parameter_modifiers (parameter_modifier))
-                        (user_type (type_identifier))))))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (lambda_literal
+        (lambda_function_type
+          (lambda_function_type_parameters
+            (lambda_parameter
+              (simple_identifier)
+              (parameter_modifiers
+                (parameter_modifier))
+              (user_type
+                (type_identifier)))))))))
+
+================================================================================
 Higher-order functions - pt 6
-==================
+================================================================================
 
 test { @Special [weak self, otherSelf] (a) in }
 
----
-(source_file
-    (call_expression
-        (simple_identifier)
-        (call_suffix
-            (lambda_literal
-                (capture_list
-                    (attribute (user_type (type_identifier)))
-                    (ownership_modifier)
-                    (simple_identifier)
-                    (simple_identifier))
-                (lambda_function_type (lambda_function_type_parameters (simple_identifier)))))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (lambda_literal
+        (capture_list
+          (attribute
+            (user_type
+              (type_identifier)))
+          (capture_list_item
+            (ownership_modifier)
+            (simple_identifier))
+          (capture_list_item
+            (simple_identifier)))
+        (lambda_function_type
+          (lambda_function_type_parameters
+            (lambda_parameter
+              (simple_identifier))))))))
+
+================================================================================
 Higher-order functions - pt 7
-==================
+================================================================================
 
 test(block: ===)
 
----
-(source_file
-    (call_expression
-        (simple_identifier)
-        (call_suffix
-            (value_arguments (value_argument (simple_identifier))))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (simple_identifier))))))
+
+================================================================================
 Higher-order functions - pt 8
-==================
+================================================================================
 
 test { ($0, someVariable) }
 
----
-(source_file
-    (call_expression
-        (simple_identifier)
-        (call_suffix
-            (lambda_literal
-                (statements
-                    (tuple_expression (simple_identifier) (simple_identifier)))))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (lambda_literal
+        (statements
+          (tuple_expression
+            (simple_identifier)
+            (simple_identifier)))))))
+
+================================================================================
 Higher-order functions - pt 9
-==================
+================================================================================
 
 test { (self, a) -> Void in }
 
----
-(source_file
-    (call_expression
-        (simple_identifier)
-        (call_suffix
-            (lambda_literal
-                (lambda_function_type
-                    (lambda_function_type_parameters (self_expression) (simple_identifier))
-                    (user_type (type_identifier)))))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (lambda_literal
+        (lambda_function_type
+          (lambda_function_type_parameters
+            (lambda_parameter
+              (self_expression))
+            (lambda_parameter
+              (simple_identifier)))
+          (user_type
+            (type_identifier)))))))
+
+================================================================================
 Higher-order functions - pt 10
-==================
+================================================================================
 
 test { (a: Any?) in foo(a) }
 
----
-(source_file
-    (call_expression
-        (simple_identifier)
-        (call_suffix
-            (lambda_literal
-                (lambda_function_type
-                    (lambda_function_type_parameters
-                        (simple_identifier)
-                        (optional_type (user_type (type_identifier)))))
-                    (statements
-                        (call_expression (simple_identifier)
-                        (call_suffix
-                            (value_arguments (value_argument (simple_identifier))))))))))
+--------------------------------------------------------------------------------
 
-===============
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (lambda_literal
+        (lambda_function_type
+          (lambda_function_type_parameters
+            (lambda_parameter
+              (simple_identifier)
+              (optional_type
+                (user_type
+                  (type_identifier))))))
+        (statements
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments
+                (value_argument
+                  (simple_identifier))))))))))
+
+================================================================================
 Higher-order functions - pt 11
-===============
+================================================================================
 
 types.flatMap { [abc, 1] }
 
----
+--------------------------------------------------------------------------------
 
-    (source_file
-      (call_expression
-        (navigation_expression
-          (simple_identifier)
-          (navigation_suffix
-            (simple_identifier)))
-        (call_suffix
-          (lambda_literal
-            (statements
-              (array_literal
-                (simple_identifier)
-                (integer_literal)))))))
+(source_file
+  (call_expression
+    (navigation_expression
+      (simple_identifier)
+      (navigation_suffix
+        (simple_identifier)))
+    (call_suffix
+      (lambda_literal
+        (statements
+          (array_literal
+            (simple_identifier)
+            (integer_literal)))))))
 
-===============
+================================================================================
 Function type with wildcard
-===============
+================================================================================
 
 private lazy var onCatClosure: (_ cat: Cat) throws -> Void = { _ in
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (property_declaration
-        (modifiers (visibility_modifier) (property_behavior_modifier))
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (type_annotation
-            (function_type
-                (tuple_type
-                    (wildcard_pattern)
-                    (simple_identifier)
-                    (user_type (type_identifier)))
-                (throws)
-                (user_type (type_identifier))))
-        (lambda_literal
-            (lambda_function_type (lambda_function_type_parameters (simple_identifier))))))
+  (property_declaration
+    (modifiers
+      (visibility_modifier)
+      (property_behavior_modifier))
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (type_annotation
+      (function_type
+        (tuple_type
+          (tuple_type_item
+            (wildcard_pattern)
+            (simple_identifier)
+            (user_type
+              (type_identifier))))
+        (throws)
+        (user_type
+          (type_identifier))))
+    (lambda_literal
+      (lambda_function_type
+        (lambda_function_type_parameters
+          (lambda_parameter
+            (simple_identifier)))))))
 
-===============
+================================================================================
 Multiple trailing lambdas
-===============
+================================================================================
 
 myInstance.registerCallbacks { } onCancelled: { }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (call_expression
-        (navigation_expression
-            (simple_identifier)
-            (navigation_suffix (simple_identifier)))
-        (call_suffix
-            (lambda_literal)
-            (simple_identifier)
-            (lambda_literal))))
+  (call_expression
+    (navigation_expression
+      (simple_identifier)
+      (navigation_suffix
+        (simple_identifier)))
+    (call_suffix
+      (lambda_literal)
+      (simple_identifier)
+      (lambda_literal))))
 
-===============
+================================================================================
 Return type fun
-===============
+================================================================================
 
 func opaqueType() -> some Equatable { return "" }
 func multipleType() -> Foo & Bar { return Foo() }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (function_declaration
-        (simple_identifier)
-        (user_type (type_identifier))
-        (function_body (statements (control_transfer_statement (line_string_literal)))))
-    (function_declaration
-        (simple_identifier)
-        (user_type (type_identifier))
-        (user_type (type_identifier))
-        (function_body (statements
-            (control_transfer_statement (call_expression (simple_identifier) (call_suffix (value_arguments))))))))
+  (function_declaration
+    (simple_identifier)
+    (opaque_type
+      (user_type
+        (type_identifier)))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (line_string_literal)))))
+  (function_declaration
+    (simple_identifier)
+    (user_type
+      (type_identifier))
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (control_transfer_statement
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments))))))))

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -1,29 +1,30 @@
-==================
+================================================================================
 Simple identifiers
-==================
+================================================================================
 
 helloWorld
 
----
+--------------------------------------------------------------------------------
 
-(source_file (simple_identifier))
+(source_file
+  (simple_identifier))
 
-==================
+================================================================================
 Boolean literals
-==================
+================================================================================
 
 true
 false
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (boolean_literal)
-    (boolean_literal))
+  (boolean_literal)
+  (boolean_literal))
 
-==================
+================================================================================
 String literals
-==================
+================================================================================
 
 "Hello World!"
 """
@@ -32,19 +33,21 @@ string.
 """
 "This string has a // comment (except not!)"
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (line_string_literal (line_str_text))
-    (multi_line_string_literal
-        (multi_line_str_text)
-        (multi_line_str_text)
-        (multi_line_str_text))
-    (line_string_literal (line_str_text)))
+  (line_string_literal
+    (line_str_text))
+  (multi_line_string_literal
+    (multi_line_str_text)
+    (multi_line_str_text)
+    (multi_line_str_text))
+  (line_string_literal
+    (line_str_text)))
 
-==================
+================================================================================
 String interpolation
-==================
+================================================================================
 
 "Sample \("string.interpolation") literal"
 """
@@ -58,27 +61,33 @@ Multiline
    And yet neither of those comments should register
 """ // This comment is valid
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (line_string_literal
-        (line_str_text)
-        (interpolated_expression (line_string_literal (line_str_text)))
-        (line_str_text))
-    (multi_line_string_literal
-        (multi_line_str_text)
-        (interpolated_expression (multi_line_string_literal (multi_line_str_text)))
-        (multi_line_str_text))
-    (line_string_literal (line_str_text))
-    (multi_line_string_literal (multi_line_str_text))
-    (comment))
+  (line_string_literal
+    (line_str_text)
+    (interpolated_expression
+      (line_string_literal
+        (line_str_text)))
+    (line_str_text))
+  (multi_line_string_literal
+    (multi_line_str_text)
+    (interpolated_expression
+      (multi_line_string_literal
+        (multi_line_str_text)))
+    (multi_line_str_text))
+  (line_string_literal
+    (line_str_text))
+  (multi_line_string_literal
+    (multi_line_str_text))
+  (comment))
 
-==================
+================================================================================
 Custom interpolation
-==================
+================================================================================
 "Hi, I'm \(format: age)"
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (line_string_literal
@@ -87,17 +96,16 @@ Custom interpolation
       (simple_identifier)
       (simple_identifier))))
 
-
-==================
+================================================================================
 Strings with newline escaping
-==================
+================================================================================
 
 """
 This is a string that acts as though it \
     is all on one line
 """
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (multi_line_string_literal
@@ -105,9 +113,9 @@ This is a string that acts as though it \
     (str_escaped_char)
     (multi_line_str_text)))
 
-==================
+================================================================================
 Integer literals
-==================
+================================================================================
 
 0
 8
@@ -117,20 +125,20 @@ Integer literals
 0o774
 0b01
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (integer_literal)
-    (integer_literal)
-    (integer_literal)
-    (integer_literal)
-    (hex_literal)
-    (oct_literal)
-    (bin_literal))
+  (integer_literal)
+  (integer_literal)
+  (integer_literal)
+  (integer_literal)
+  (hex_literal)
+  (oct_literal)
+  (bin_literal))
 
-==================
+================================================================================
 Real literals
-==================
+================================================================================
 
 0.0
 -23.434
@@ -138,39 +146,56 @@ Real literals
 4.3
 +53.9e-3
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (real_literal)
-    (prefix_expression (real_literal))
-    (real_literal)
-    (real_literal)
-    (prefix_expression (real_literal)))
+  (real_literal)
+  (prefix_expression
+    (real_literal))
+  (real_literal)
+  (real_literal)
+  (prefix_expression
+    (real_literal)))
 
-==================
+================================================================================
 Collections
-==================
+================================================================================
 
 let numbers = [1, 2, 3]
 let numerals = [1: "I", 4: "IV", 5: "V", 10: "X"]
 
----
+--------------------------------------------------------------------------------
+
 (source_file
-    (property_declaration
-        (value_binding_pattern
-            (non_binding_pattern (simple_identifier)))
-        (array_literal (integer_literal) (integer_literal) (integer_literal)))
-    (property_declaration
-        (value_binding_pattern
-            (non_binding_pattern (simple_identifier)))
-        (dictionary_literal
-            (integer_literal) (line_string_literal (line_str_text))
-            (integer_literal) (line_string_literal (line_str_text))
-            (integer_literal) (line_string_literal (line_str_text))
-            (integer_literal) (line_string_literal (line_str_text)))))
-=====
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (array_literal
+      (integer_literal)
+      (integer_literal)
+      (integer_literal)))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (dictionary_literal
+      (integer_literal)
+      (line_string_literal
+        (line_str_text))
+      (integer_literal)
+      (line_string_literal
+        (line_str_text))
+      (integer_literal)
+      (line_string_literal
+        (line_str_text))
+      (integer_literal)
+      (line_string_literal
+        (line_str_text)))))
+
+================================================================================
 Trailing commas
-=====
+================================================================================
 
 [
     "Time": Date.now(),
@@ -179,41 +204,51 @@ Trailing commas
 
 [1, 2, 3, 4, 5,]
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (dictionary_literal
-        (line_string_literal (line_str_text))
-        (call_expression
-            (navigation_expression
-                (simple_identifier)
-                (navigation_suffix (simple_identifier)))
-            (call_suffix (value_arguments)))
-        (line_string_literal (line_str_text))
-        (boolean_literal))
-    (array_literal
-        (integer_literal) (integer_literal) (integer_literal) (integer_literal) (integer_literal)))
+  (dictionary_literal
+    (line_string_literal
+      (line_str_text))
+    (call_expression
+      (navigation_expression
+        (simple_identifier)
+        (navigation_suffix
+          (simple_identifier)))
+      (call_suffix
+        (value_arguments)))
+    (line_string_literal
+      (line_str_text))
+    (boolean_literal))
+  (array_literal
+    (integer_literal)
+    (integer_literal)
+    (integer_literal)
+    (integer_literal)
+    (integer_literal)))
 
-==================
+================================================================================
 Nil
-==================
+================================================================================
 
 let _ = nil
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (property_declaration (value_binding_pattern (non_binding_pattern (wildcard_pattern)))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (wildcard_pattern)))))
 
-
-==================
+================================================================================
 Raw strings
-==================
+================================================================================
 
 let _ = #"Hello, world!"#
 let _ = ##"Hello, so-called "world"!"##
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
@@ -229,9 +264,9 @@ let _ = ##"Hello, so-called "world"!"##
     (raw_string_literal
       (raw_str_end_part))))
 
-==================
+================================================================================
 Raw strings with interpolation
-==================
+================================================================================
 
 extension URL {
     func html(withTitle title: String) -> String {
@@ -239,17 +274,17 @@ extension URL {
     }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (class_declaration
-    (identifier
-      (simple_identifier))
+    (user_type
+      (type_identifier))
     (class_body
       (function_declaration
         (simple_identifier)
-        (external_parameter_name)
         (parameter
+          (simple_identifier)
           (simple_identifier)
           (user_type
             (type_identifier)))
@@ -261,19 +296,19 @@ extension URL {
               (raw_string_literal
                 (raw_str_part)
                 (raw_str_interpolation
-                    (raw_str_interpolation_start)
-                    (interpolated_expression
-                        (simple_identifier)))
+                  (raw_str_interpolation_start)
+                  (interpolated_expression
+                    (simple_identifier)))
                 (raw_str_part)
                 (raw_str_interpolation
-                    (raw_str_interpolation_start)
-                    (interpolated_expression
-                        (simple_identifier)))
+                  (raw_str_interpolation_start)
+                  (interpolated_expression
+                    (simple_identifier)))
                 (raw_str_end_part)))))))))
 
-==================
+================================================================================
 Raw strings interpolation edge cases
-==================
+================================================================================
 
 print(#"Hello \#(world /* commented out)"#)  */ )"#)
 
@@ -281,7 +316,7 @@ let _ = ##"Multiple pound signs \##(interpolated): still one part "# not done ye
 let _ = ##"Fake \#(interpolation) and unused # pound signs "##
 let _ = ##"\##(a)\#(b)\##(c)\#(d)"# ##"##
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (call_expression
@@ -292,10 +327,10 @@ let _ = ##"\##(a)\#(b)\##(c)\#(d)"# ##"##
           (raw_string_literal
             (raw_str_part)
             (raw_str_interpolation
-                (raw_str_interpolation_start)
-                (interpolated_expression
-                    (simple_identifier))
-                (multiline_comment))
+              (raw_str_interpolation_start)
+              (interpolated_expression
+                (simple_identifier))
+              (multiline_comment))
             (raw_str_end_part))))))
   (property_declaration
     (value_binding_pattern
@@ -304,9 +339,9 @@ let _ = ##"\##(a)\#(b)\##(c)\#(d)"# ##"##
     (raw_string_literal
       (raw_str_part)
       (raw_str_interpolation
-          (raw_str_interpolation_start)
-          (interpolated_expression
-              (simple_identifier)))
+        (raw_str_interpolation_start)
+        (interpolated_expression
+          (simple_identifier)))
       (raw_str_end_part)))
   (property_declaration
     (value_binding_pattern
@@ -321,50 +356,54 @@ let _ = ##"\##(a)\#(b)\##(c)\#(d)"# ##"##
     (raw_string_literal
       (raw_str_part)
       (raw_str_interpolation
-          (raw_str_interpolation_start)
-          (interpolated_expression
-              (simple_identifier)))
+        (raw_str_interpolation_start)
+        (interpolated_expression
+          (simple_identifier)))
       (raw_str_part)
       (raw_str_interpolation
-          (raw_str_interpolation_start)
-          (interpolated_expression
-              (simple_identifier)))
+        (raw_str_interpolation_start)
+        (interpolated_expression
+          (simple_identifier)))
       (raw_str_end_part))))
 
-===
+================================================================================
 Unicode escape sequences
-===
+================================================================================
 
 let unicodeEscaping = "\u{8}"
 let anotherUnicode = "…\u{2060}"
 let infinity = "\u{221E}"
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
     (value_binding_pattern
       (non_binding_pattern
         (simple_identifier)))
-    (line_string_literal (str_escaped_char)))
+    (line_string_literal
+      (str_escaped_char)))
   (property_declaration
     (value_binding_pattern
       (non_binding_pattern
         (simple_identifier)))
-    (line_string_literal (line_str_text) (str_escaped_char)))
+    (line_string_literal
+      (line_str_text)
+      (str_escaped_char)))
   (property_declaration
     (value_binding_pattern
       (non_binding_pattern
         (simple_identifier)))
-    (line_string_literal (str_escaped_char))))
+    (line_string_literal
+      (str_escaped_char))))
 
-===
+================================================================================
 Playground literals
-===
+================================================================================
 
 let playgroundLiteral = #imageLiteral(resourceName: "heart")
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
@@ -372,5 +411,5 @@ let playgroundLiteral = #imageLiteral(resourceName: "heart")
       (non_binding_pattern
         (simple_identifier)))
     (simple_identifier)
-    (line_string_literal (line_str_text))))
-
+    (line_string_literal
+      (line_str_text))))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -1,49 +1,65 @@
-==================
+================================================================================
 Let statements
-==================
+================================================================================
 
 let singleVariable = 1
 let (tuple1, tuple2) = (2, 3)
 let `default` = 0
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (integer_literal))
-    (property_declaration
-        (value_binding_pattern
-            (non_binding_pattern
-                (non_binding_pattern (simple_identifier))
-                (non_binding_pattern (simple_identifier))))
-        (tuple_expression (integer_literal) (integer_literal)))
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (integer_literal)))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (integer_literal))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (non_binding_pattern
+          (simple_identifier))
+        (non_binding_pattern
+          (simple_identifier))))
+    (tuple_expression
+      (integer_literal)
+      (integer_literal)))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (integer_literal)))
 
-==================
+================================================================================
 C-style compound declaration
-==================
+================================================================================
 
 var one = 1, two = 2, four = 4, eight = 8
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (integer_literal)
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (integer_literal)
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (integer_literal)
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (integer_literal))) 
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (integer_literal)
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (integer_literal)
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (integer_literal)
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (integer_literal)))
 
-==================
+================================================================================
 For statements
-==================
+================================================================================
 
 for value: MyType in values {
     print(value)
@@ -57,44 +73,50 @@ for case .some((.some(0), .some(1))) in crazyValues {
 for var value in values where value.isExcellent() {
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (for_statement
+  (for_statement
+    (simple_identifier)
+    (type_annotation
+      (user_type
+        (type_identifier)))
+    (simple_identifier)
+    (statements
+      (call_expression
         (simple_identifier)
-        (type_annotation (user_type (type_identifier)))
-        (simple_identifier)
-        (statements
-            (call_expression
-                (simple_identifier)
-                (call_suffix
-                    (value_arguments
-                        (value_argument (simple_identifier)))))))
-    (for_statement
-        (simple_identifier)
-        (simple_identifier)
-        (simple_identifier))
-    (for_statement
-        (simple_identifier)
-        (simple_identifier)
-        (integer_literal)
-        (simple_identifier)
-        (integer_literal)
-        (simple_identifier))
-    (for_statement
-        (non_binding_pattern (simple_identifier))
-        (simple_identifier)
-        (where_clause
-            (where_keyword)
-            (call_expression
-                (navigation_expression
-                    (simple_identifier)
-                    (navigation_suffix (simple_identifier)))
-                (call_suffix (value_arguments))))))
+        (call_suffix
+          (value_arguments
+            (value_argument
+              (simple_identifier)))))))
+  (for_statement
+    (simple_identifier)
+    (simple_identifier)
+    (simple_identifier))
+  (for_statement
+    (simple_identifier)
+    (simple_identifier)
+    (integer_literal)
+    (simple_identifier)
+    (integer_literal)
+    (simple_identifier))
+  (for_statement
+    (non_binding_pattern
+      (simple_identifier))
+    (simple_identifier)
+    (where_clause
+      (where_keyword)
+      (call_expression
+        (navigation_expression
+          (simple_identifier)
+          (navigation_suffix
+            (simple_identifier)))
+        (call_suffix
+          (value_arguments))))))
 
-==================
+================================================================================
 Weird for statements
-==================
+================================================================================
 
 for case let fileUrl as URL in directory {
 }
@@ -111,42 +133,47 @@ outerLoop: for outerObject in dataArray {
     }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (for_statement
-        (non_binding_pattern
-            (non_binding_pattern
-                (simple_identifier))
-            (user_type (type_identifier)))
+  (for_statement
+    (non_binding_pattern
+      (non_binding_pattern
         (simple_identifier))
-    (for_statement
-        (non_binding_pattern
-            (non_binding_pattern
-                (simple_identifier))
-            (non_binding_pattern
-                (simple_identifier)))
+      (user_type
+        (type_identifier)))
+    (simple_identifier))
+  (for_statement
+    (non_binding_pattern
+      (non_binding_pattern
         (simple_identifier))
-    (statement_label)
-    (for_statement
+      (non_binding_pattern
+        (simple_identifier)))
+    (simple_identifier))
+  (statement_label)
+  (for_statement
+    (simple_identifier)
+    (simple_identifier)
+    (statements
+      (for_statement
         (simple_identifier)
         (simple_identifier)
         (statements
-            (for_statement
-                (simple_identifier)
-                (simple_identifier)
-                (statements
-                    (if_statement
-                        (equality_expression (simple_identifier) (simple_identifier))
-                        (statements
-                            (assignment
-                                (directly_assignable_expression (simple_identifier))
-                                (boolean_literal))
-                            (control_transfer_statement (simple_identifier)))))))))
+          (if_statement
+            (equality_expression
+              (simple_identifier)
+              (simple_identifier))
+            (statements
+              (assignment
+                (directly_assignable_expression
+                  (simple_identifier))
+                (boolean_literal))
+              (control_transfer_statement
+                (simple_identifier)))))))))
 
-==================
+================================================================================
 While and friends
-==================
+================================================================================
 
 while idx > 0, input.count > 0 {
     // ...
@@ -160,22 +187,40 @@ repeat {
     // ...
 } while something()
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (while_statement
-        (comparison_expression (simple_identifier) (integer_literal))
-        (comparison_expression (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier))) (integer_literal))
-        (comment))
-    (while_statement
-        (value_binding_pattern (non_binding_pattern (simple_identifier) (simple_identifier)))
-        (call_expression (simple_identifier) (call_suffix (value_arguments)))
-        (comment))
-    (repeat_while_statement (comment) (call_expression (simple_identifier) (call_suffix (value_arguments)))))
+  (while_statement
+    (comparison_expression
+      (simple_identifier)
+      (integer_literal))
+    (comparison_expression
+      (navigation_expression
+        (simple_identifier)
+        (navigation_suffix
+          (simple_identifier)))
+      (integer_literal))
+    (comment))
+  (while_statement
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (comment))
+  (repeat_while_statement
+    (comment)
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))))
 
-==================
+================================================================================
 Switch statements
-==================
+================================================================================
 
 switch something {
     case .pattern: return "Hello"
@@ -184,26 +229,43 @@ switch something {
     default: return ":)"
 }
 
----
-(source_file
-    (switch_statement
-        (simple_identifier)
-        (switch_entry
-            (switch_pattern (simple_identifier))
-            (statements (control_transfer_statement (line_string_literal (line_str_text)))))
-        (switch_entry
-            (switch_pattern (simple_identifier))
-            (statements (control_transfer_statement (line_string_literal (line_str_text)))))
-        (switch_entry
-            (switch_pattern (line_string_literal (line_str_text)))
-            (statements (control_transfer_statement (line_string_literal (line_str_text)))))
-        (switch_entry
-            (default_keyword)
-            (statements (control_transfer_statement (line_string_literal (line_str_text)))))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (switch_statement
+    (simple_identifier)
+    (switch_entry
+      (switch_pattern
+        (simple_identifier))
+      (statements
+        (control_transfer_statement
+          (line_string_literal
+            (line_str_text)))))
+    (switch_entry
+      (switch_pattern
+        (simple_identifier))
+      (statements
+        (control_transfer_statement
+          (line_string_literal
+            (line_str_text)))))
+    (switch_entry
+      (switch_pattern
+        (line_string_literal
+          (line_str_text)))
+      (statements
+        (control_transfer_statement
+          (line_string_literal
+            (line_str_text)))))
+    (switch_entry
+      (default_keyword)
+      (statements
+        (control_transfer_statement
+          (line_string_literal
+            (line_str_text)))))))
+
+================================================================================
 Weird switch statements
-==================
+================================================================================
 
 switch something {
     case let .pattern2(_, bound): fallthrough
@@ -218,42 +280,66 @@ case let .isExecutable(path?):
     return "File is executable: \(path)"
 }
 
----
-(source_file
-    (switch_statement
-        (simple_identifier)
-        (switch_entry
-            (switch_pattern
-                (non_binding_pattern
-                    (simple_identifier)
-                    (wildcard_pattern)
-                    (simple_identifier)))
-            (statements (simple_identifier)))
-        (switch_entry
-            (switch_pattern (simple_identifier))
-            (where_keyword)
-            (simple_identifier)
-            (switch_pattern (simple_identifier))
-            (statements (simple_identifier)))
-        (switch_entry
-            (modifiers (attribute (user_type (type_identifier))))
-            (default_keyword)
-            (statements (control_transfer_statement (line_string_literal (line_str_text))))))
-    (switch_statement
-        (self_expression)
-        (switch_entry
-            (switch_pattern
-                    (simple_identifier)
-                    (non_binding_pattern (simple_identifier)))
-            (statements (control_transfer_statement (line_string_literal (line_str_text) (interpolated_expression (simple_identifier))))))
-        (switch_entry
-            (switch_pattern
-                (non_binding_pattern (simple_identifier) (simple_identifier)))
-            (statements (control_transfer_statement (line_string_literal (line_str_text) (interpolated_expression (simple_identifier))))))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (switch_statement
+    (simple_identifier)
+    (switch_entry
+      (switch_pattern
+        (non_binding_pattern
+          (simple_identifier)
+          (wildcard_pattern)
+          (simple_identifier)))
+      (statements
+        (simple_identifier)))
+    (switch_entry
+      (switch_pattern
+        (simple_identifier))
+      (where_keyword)
+      (simple_identifier)
+      (switch_pattern
+        (simple_identifier))
+      (statements
+        (simple_identifier)))
+    (switch_entry
+      (modifiers
+        (attribute
+          (user_type
+            (type_identifier))))
+      (default_keyword)
+      (statements
+        (control_transfer_statement
+          (line_string_literal
+            (line_str_text))))))
+  (switch_statement
+    (self_expression)
+    (switch_entry
+      (switch_pattern
+        (simple_identifier)
+        (non_binding_pattern
+          (simple_identifier)))
+      (statements
+        (control_transfer_statement
+          (line_string_literal
+            (line_str_text)
+            (interpolated_expression
+              (simple_identifier))))))
+    (switch_entry
+      (switch_pattern
+        (non_binding_pattern
+          (simple_identifier)
+          (simple_identifier)))
+      (statements
+        (control_transfer_statement
+          (line_string_literal
+            (line_str_text)
+            (interpolated_expression
+              (simple_identifier))))))))
+
+================================================================================
 Imports
-==================
+================================================================================
 
 import Foundation
 import class SomeModule.SomeClass
@@ -262,17 +348,26 @@ class Foo { }
 
 import SomethingElse
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (import_declaration (identifier (simple_identifier)))
-    (import_declaration (identifier (simple_identifier) (simple_identifier)))
-    (class_declaration (type_identifier) (class_body))
-    (import_declaration (identifier (simple_identifier))))
+  (import_declaration
+    (identifier
+      (simple_identifier)))
+  (import_declaration
+    (identifier
+      (simple_identifier)
+      (simple_identifier)))
+  (class_declaration
+    (type_identifier)
+    (class_body))
+  (import_declaration
+    (identifier
+      (simple_identifier))))
 
-==================
+================================================================================
 Do-catch
-==================
+================================================================================
 
 do {
     let b = 1
@@ -288,61 +383,76 @@ do {
     let c = 1
 }
 
----
-(source_file
-    (do_statement
-        (statements
-            (property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (integer_literal)))
-        (catch_block
-            (catch_keyword)
-            (binding_pattern
-                (binding_pattern
-                    (non_binding_pattern
-                        (simple_identifier)))
-                    (user_type (type_identifier))))
-        (catch_block
-            (catch_keyword)
-            (binding_pattern
-                (user_type (type_identifier))
-                (simple_identifier)))
-        (catch_block
-            (catch_keyword)
-            (binding_pattern
-                (binding_pattern
-                    (non_binding_pattern
-                        (simple_identifier)))
-                    (user_type (type_identifier)))
-            (where_clause
-                (where_keyword)
-                (equality_expression
-                    (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
-                    (integer_literal))))
-        (catch_block
-            (catch_keyword)
-            (binding_pattern
-                (non_binding_pattern
-                    (user_type (type_identifier))
-                    (simple_identifier)
-                    (simple_identifier))))
-        (catch_block
-            (catch_keyword)
-            (binding_pattern
-                (user_type (type_identifier))
-                (simple_identifier)
-                (simple_identifier)
-                (non_binding_pattern (simple_identifier))))
-        (catch_block (catch_keyword)))
-    (do_statement
-        (statements
-            (property_declaration
-                (value_binding_pattern (non_binding_pattern (simple_identifier)))
-                (integer_literal)))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (do_statement
+    (statements
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (integer_literal)))
+    (catch_block
+      (catch_keyword)
+      (binding_pattern
+        (binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (user_type
+          (type_identifier))))
+    (catch_block
+      (catch_keyword)
+      (binding_pattern
+        (user_type
+          (type_identifier))
+        (simple_identifier)))
+    (catch_block
+      (catch_keyword)
+      (binding_pattern
+        (binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (user_type
+          (type_identifier)))
+      (where_clause
+        (where_keyword)
+        (equality_expression
+          (navigation_expression
+            (simple_identifier)
+            (navigation_suffix
+              (simple_identifier)))
+          (integer_literal))))
+    (catch_block
+      (catch_keyword)
+      (binding_pattern
+        (non_binding_pattern
+          (user_type
+            (type_identifier))
+          (simple_identifier)
+          (simple_identifier))))
+    (catch_block
+      (catch_keyword)
+      (binding_pattern
+        (user_type
+          (type_identifier))
+        (simple_identifier)
+        (simple_identifier)
+        (non_binding_pattern
+          (simple_identifier))))
+    (catch_block
+      (catch_keyword)))
+  (do_statement
+    (statements
+      (property_declaration
+        (value_binding_pattern
+          (non_binding_pattern
+            (simple_identifier)))
+        (integer_literal)))))
+
+================================================================================
 If let statements
-==================
+================================================================================
 
 if let something = doThing() {
     anotherThing()
@@ -357,29 +467,58 @@ if let something: MyType = doThing() {
 someLabel: if a.isEmpty, let b = getB() {
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (if_statement
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (call_expression (simple_identifier) (call_suffix (value_arguments)))
-        (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
-    (if_statement
-        (binding_pattern (simple_identifier) (wildcard_pattern))
-        (call_expression (simple_identifier) (call_suffix (value_arguments))))
-    (if_statement
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (type_annotation (user_type (type_identifier)))
-        (call_expression (simple_identifier) (call_suffix (value_arguments))))
-    (statement_label)
-    (if_statement
-        (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (call_expression (simple_identifier) (call_suffix (value_arguments)))))
+  (if_statement
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (statements
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments)))))
+  (if_statement
+    (binding_pattern
+      (simple_identifier)
+      (wildcard_pattern))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments))))
+  (if_statement
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (type_annotation
+      (user_type
+        (type_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments))))
+  (statement_label)
+  (if_statement
+    (navigation_expression
+      (simple_identifier)
+      (navigation_suffix
+        (simple_identifier)))
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))))
 
-===============
+================================================================================
 If let with function call
-===============
+================================================================================
 
 func doSomething() {
     if let a = try? Foo.getValue("key") {
@@ -388,36 +527,37 @@ func doSomething() {
     return defaultValue
 }
 
----
+--------------------------------------------------------------------------------
 
-    (source_file
-      (function_declaration
-        (simple_identifier)
-        (function_body
-          (statements
-            (if_statement
-              (value_binding_pattern
-                (non_binding_pattern
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_body
+      (statements
+        (if_statement
+          (value_binding_pattern
+            (non_binding_pattern
+              (simple_identifier)))
+          (try_expression
+            (call_expression
+              (navigation_expression
+                (simple_identifier)
+                (navigation_suffix
                   (simple_identifier)))
-              (try_expression
-                (call_expression
-                  (navigation_expression
-                    (simple_identifier)
-                    (navigation_suffix
-                      (simple_identifier)))
-                  (call_suffix
-                     (value_arguments
-                       (value_argument
-                         (line_string_literal (line_str_text)))))))
-              (statements
-                (control_transfer_statement
-                  (simple_identifier))))
+              (call_suffix
+                (value_arguments
+                  (value_argument
+                    (line_string_literal
+                      (line_str_text)))))))
+          (statements
             (control_transfer_statement
-              (simple_identifier))))))
+              (simple_identifier))))
+        (control_transfer_statement
+          (simple_identifier))))))
 
-==================
+================================================================================
 Compound if let
-==================
+================================================================================
 
 if let something = doThing(), something.isSpecial() {
     anotherThing()
@@ -427,30 +567,52 @@ if let something = doThing(), let somethingElse = something.somethingElse() {
     // Nothing
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (if_statement
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (call_expression (simple_identifier) (call_suffix (value_arguments)))
-        (call_expression
-            (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
-            (call_suffix (value_arguments)))
-        (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
-    (if_statement
-        (value_binding_pattern
-            (non_binding_pattern (simple_identifier)))
-        (call_expression (simple_identifier) (call_suffix (value_arguments)))
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (call_expression
-            (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
-            (call_suffix (value_arguments)))
-        (comment)))
+  (if_statement
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (call_expression
+      (navigation_expression
+        (simple_identifier)
+        (navigation_suffix
+          (simple_identifier)))
+      (call_suffix
+        (value_arguments)))
+    (statements
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments)))))
+  (if_statement
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (navigation_expression
+        (simple_identifier)
+        (navigation_suffix
+          (simple_identifier)))
+      (call_suffix
+        (value_arguments)))
+    (comment)))
 
-
-==================
+================================================================================
 Else if...
-==================
+================================================================================
 
 if let aPrime = a {
 } else if let bPrime = b {
@@ -461,24 +623,34 @@ if a == b {
 else if let cPrime = c {
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
+  (if_statement
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (simple_identifier)
+    (else)
     (if_statement
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (simple_identifier)
-        (else)
-        (if_statement (value_binding_pattern (non_binding_pattern (simple_identifier))) (simple_identifier)))
+      (value_binding_pattern
+        (non_binding_pattern
+          (simple_identifier)))
+      (simple_identifier)))
+  (if_statement
+    (equality_expression
+      (simple_identifier)
+      (simple_identifier))
+    (else)
     (if_statement
-        (equality_expression (simple_identifier) (simple_identifier))
-        (else)
-        (if_statement
-            (value_binding_pattern (non_binding_pattern (simple_identifier)))
-            (simple_identifier))))
+      (value_binding_pattern
+        (non_binding_pattern
+          (simple_identifier)))
+      (simple_identifier))))
 
-===
+================================================================================
 Else interacts with comments
-===
+================================================================================
 
 if foo {
   fooVal = 0; // A comment
@@ -487,7 +659,7 @@ if foo {
 else if bar {
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (if_statement
@@ -503,9 +675,9 @@ else if bar {
     (if_statement
       (simple_identifier))))
 
-==================
+================================================================================
 Guard statements
-==================
+================================================================================
 
 guard let something = doThing() else {
     anotherThing()
@@ -520,53 +692,93 @@ guard case .someCase(ident: let foo)? = otherThing() else {
 
 guard case justIdentifier = bound else { }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (guard_statement
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (call_expression (simple_identifier) (call_suffix (value_arguments)))
-        (else)
-        (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
-    (guard_statement
-        (call_expression (simple_identifier) (call_suffix (value_arguments)))
-        (else)
-        (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
-    (guard_statement
-        (binding_pattern
-            (simple_identifier) (simple_identifier)
-            (non_binding_pattern (simple_identifier)))
-        (call_expression (simple_identifier) (call_suffix (value_arguments))) (else))
-    (guard_statement (binding_pattern (simple_identifier)) (simple_identifier) (else)))
-==================
+  (guard_statement
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (else)
+    (statements
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments)))))
+  (guard_statement
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (else)
+    (statements
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments)))))
+  (guard_statement
+    (binding_pattern
+      (simple_identifier)
+      (simple_identifier)
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (else))
+  (guard_statement
+    (binding_pattern
+      (simple_identifier))
+    (simple_identifier)
+    (else)))
+
+================================================================================
 Compound guard
-==================
+================================================================================
 
 guard let something = doThing(), something.isSpecial() else {
     anotherThing()
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (guard_statement
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (call_expression (simple_identifier) (call_suffix (value_arguments)))
-        (call_expression
-            (navigation_expression (simple_identifier) (navigation_suffix (simple_identifier)))
-            (call_suffix (value_arguments)))
-        (else)
-        (statements (call_expression (simple_identifier) (call_suffix (value_arguments))))))
+  (guard_statement
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments)))
+    (call_expression
+      (navigation_expression
+        (simple_identifier)
+        (navigation_suffix
+          (simple_identifier)))
+      (call_suffix
+        (value_arguments)))
+    (else)
+    (statements
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments))))))
 
-===
+================================================================================
 Type annotation on `guard case let`
-===
+================================================================================
 
 guard case let size: Int = variable.size else {
     return nil
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (guard_statement
@@ -584,9 +796,9 @@ guard case let size: Int = variable.size else {
     (statements
       (control_transfer_statement))))
 
-================
+================================================================================
 Availability conditions
-================
+================================================================================
 
 if #available(iOS 14.0, *) {
     doSomething()
@@ -598,27 +810,42 @@ if #available(macOS 10.12.0, *) {
     return 0
 }
 
----
+--------------------------------------------------------------------------------
+
 (source_file
-    (if_statement (availability_condition
-        (identifier (simple_identifier))
-        (integer_literal) (integer_literal))
-        (statements (call_expression (simple_identifier) (call_suffix (value_arguments)))))
-    (if_statement (availability_condition
-        (identifier (simple_identifier))
-        (integer_literal) (integer_literal) (integer_literal))
-        (statements (control_transfer_statement (integer_literal)))
-        (else)
-        (statements (control_transfer_statement (integer_literal)))))
+  (if_statement
+    (availability_condition
+      (identifier
+        (simple_identifier))
+      (integer_literal)
+      (integer_literal))
+    (statements
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments)))))
+  (if_statement
+    (availability_condition
+      (identifier
+        (simple_identifier))
+      (integer_literal)
+      (integer_literal)
+      (integer_literal))
+    (statements
+      (control_transfer_statement
+        (integer_literal)))
+    (else)
+    (statements
+      (control_transfer_statement
+        (integer_literal)))))
 
-
-===
+================================================================================
 Unicode identifiers
-===
+================================================================================
 
 let ø = unicode()
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
@@ -630,9 +857,9 @@ let ø = unicode()
       (call_suffix
         (value_arguments)))))
 
-===
+================================================================================
 Contextual keywords are usable as identifiers
-===
+================================================================================
 
 public init() {
     // `prefix` doesn't work as a function modifier here, so it's legal as an identifier
@@ -647,7 +874,7 @@ public init() {
     func innerFunc() { }
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (function_declaration
@@ -679,9 +906,9 @@ public init() {
           (simple_identifier)
           (function_body))))))
 
-===
+================================================================================
 Compiler diagnostics
-===
+================================================================================
 
 #if SOME_FLAG
 #error("SOME_FLAG must not be enabled!")
@@ -691,7 +918,7 @@ Compiler diagnostics
 #sourceLocation(file: "SomeFile.swift", line: 99)
 #endif
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (directive)
@@ -701,4 +928,3 @@ Compiler diagnostics
   (directive)
   (directive)
   (directive))
-

--- a/corpus/types.txt
+++ b/corpus/types.txt
@@ -1,229 +1,305 @@
-==================
+================================================================================
 Type references
-==================
+================================================================================
 
 something as Int
 something as? A
 something as! A
 
----
+--------------------------------------------------------------------------------
 
-(source_file 
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (user_type (type_identifier)))
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (user_type (type_identifier)))
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (user_type (type_identifier))))
+(source_file
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (user_type
+      (type_identifier)))
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (user_type
+      (type_identifier)))
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (user_type
+      (type_identifier))))
 
-==================
+================================================================================
 Nested types
-==================
+================================================================================
 
 something as Some.NestedType
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (user_type (type_identifier) (type_identifier))))
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (user_type
+      (type_identifier)
+      (type_identifier))))
 
-==================
+================================================================================
 Deeply nested types
-==================
+================================================================================
 
 somethingElse as A.Deeply.Nested.Type
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (user_type
-            (type_identifier)
-            (type_identifier)
-            (type_identifier)
-            (type_identifier))))
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (user_type
+      (type_identifier)
+      (type_identifier)
+      (type_identifier)
+      (type_identifier))))
 
-==================
+================================================================================
 Generic parameterized types
-==================
+================================================================================
 
 something as Generic<T>
 something as Generic<A, Type>
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (user_type (type_identifier)
-            (type_arguments
-                (user_type (type_identifier)))))
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (user_type (type_identifier)
-            (type_arguments
-                (user_type (type_identifier))
-                (user_type (type_identifier))))))
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (user_type
+      (type_identifier)
+      (type_arguments
+        (user_type
+          (type_identifier)))))
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (user_type
+      (type_identifier)
+      (type_arguments
+        (user_type
+          (type_identifier))
+        (user_type
+          (type_identifier))))))
 
-==================
+================================================================================
 Function types
-==================
+================================================================================
 
 unitFunction as () -> Unit
 consumer as (Int) -> Unit
 configurator as (inout Config) -> Unit
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (function_type
-            (tuple_type)
-            (user_type (type_identifier))))
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (function_type
-            (tuple_type (user_type (type_identifier)))
-            (user_type (type_identifier))))
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (function_type
-            (tuple_type
-                (parameter_modifiers (parameter_modifier))
-                (user_type (type_identifier)))
-            (user_type (type_identifier)))))
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (function_type
+      (tuple_type)
+      (user_type
+        (type_identifier))))
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (function_type
+      (tuple_type
+        (tuple_type_item
+          (user_type
+            (type_identifier))))
+      (user_type
+        (type_identifier))))
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (function_type
+      (tuple_type
+        (tuple_type_item
+          (parameter_modifiers
+            (parameter_modifier))
+          (user_type
+            (type_identifier))))
+      (user_type
+        (type_identifier)))))
 
-==================
+================================================================================
 Function types with multiple parameters
-==================
+================================================================================
 
 a as (Int, Generic<T>, Boolean) -> Unit
 b as (Nested.Type, (Int)) -> Unit
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (function_type
-            (tuple_type
-                (user_type (type_identifier))
-                (user_type
-                    (type_identifier)
-                    (type_arguments (user_type (type_identifier))))
-                (user_type (type_identifier)))
-            (user_type (type_identifier))))
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (function_type
-            (tuple_type
-                (user_type (type_identifier) (type_identifier))
-                (tuple_type (user_type (type_identifier))))
-            (user_type (type_identifier)))))
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (function_type
+      (tuple_type
+        (tuple_type_item
+          (user_type
+            (type_identifier)))
+        (tuple_type_item
+          (user_type
+            (type_identifier)
+            (type_arguments
+              (user_type
+                (type_identifier)))))
+        (tuple_type_item
+          (user_type
+            (type_identifier))))
+      (user_type
+        (type_identifier))))
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (function_type
+      (tuple_type
+        (tuple_type_item
+          (user_type
+            (type_identifier)
+            (type_identifier)))
+        (tuple_type_item
+          (tuple_type
+            (tuple_type_item
+              (user_type
+                (type_identifier))))))
+      (user_type
+        (type_identifier)))))
 
-==================
+================================================================================
 Types with named parameters (function or tuple)
-==================
+================================================================================
 
 a as (first: A, second: B)
 -> Unit
 let c: (third: C, fourth: D)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (as_expression
-        (simple_identifier)
-        (as_operator)
-        (function_type
-            (tuple_type
-                (simple_identifier)
-                (user_type (type_identifier))
-                (simple_identifier)
-                (user_type (type_identifier)))
-            (user_type (type_identifier))))
-    (property_declaration
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (type_annotation
-            (tuple_type
-                (simple_identifier)
-                (user_type (type_identifier))
-                (simple_identifier)
-                (user_type (type_identifier))))))
-==================
+  (as_expression
+    (simple_identifier)
+    (as_operator)
+    (function_type
+      (tuple_type
+        (tuple_type_item
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (tuple_type_item
+          (simple_identifier)
+          (user_type
+            (type_identifier))))
+      (user_type
+        (type_identifier))))
+  (property_declaration
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (type_annotation
+      (tuple_type
+        (tuple_type_item
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (tuple_type_item
+          (simple_identifier)
+          (user_type
+            (type_identifier)))))))
+
+================================================================================
 Nested optional types
-==================
+================================================================================
 
 private var dictionary: [String: Any?]?
 
----
+--------------------------------------------------------------------------------
+
 (source_file
-    (property_declaration
-        (modifiers (visibility_modifier))
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (type_annotation
-            (optional_type
-                (dictionary_type
-                    (user_type (type_identifier))
-                    (optional_type (user_type (type_identifier)))))))) 
-==================
+  (property_declaration
+    (modifiers
+      (visibility_modifier))
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (type_annotation
+      (optional_type
+        (dictionary_type
+          (user_type
+            (type_identifier))
+          (optional_type
+            (user_type
+              (type_identifier))))))))
+
+================================================================================
 Implicitly unwrapped optional types
-==================
+================================================================================
 
 private var dictionary: [String: Any?]!
 
----
-(source_file
-    (property_declaration
-        (modifiers (visibility_modifier))
-        (value_binding_pattern (non_binding_pattern (simple_identifier)))
-        (type_annotation
-            (dictionary_type
-                (user_type (type_identifier))
-                (optional_type (user_type (type_identifier)))))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (property_declaration
+    (modifiers
+      (visibility_modifier))
+    (value_binding_pattern
+      (non_binding_pattern
+        (simple_identifier)))
+    (type_annotation
+      (dictionary_type
+        (user_type
+          (type_identifier))
+        (optional_type
+          (user_type
+            (type_identifier)))))))
+
+================================================================================
 Type aliases
-==================
+================================================================================
 
 public typealias Callback<T> = (T) -> Void
 public typealias IntCallback = Callback<T>
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-    (typealias_declaration
-        (modifiers (visibility_modifier))
-            (type_identifier)
-            (type_parameters (type_parameter (type_identifier)))
-            (function_type (tuple_type (user_type (type_identifier))) (user_type (type_identifier))))
-    (typealias_declaration
-        (modifiers (visibility_modifier))
-        (type_identifier)
-        (user_type (type_identifier) (type_arguments (user_type (type_identifier))))))
+  (typealias_declaration
+    (modifiers
+      (visibility_modifier))
+    (type_identifier)
+    (type_parameters
+      (type_parameter
+        (type_identifier)))
+    (function_type
+      (tuple_type
+        (tuple_type_item
+          (user_type
+            (type_identifier))))
+      (user_type
+        (type_identifier))))
+  (typealias_declaration
+    (modifiers
+      (visibility_modifier))
+    (type_identifier)
+    (user_type
+      (type_identifier)
+      (type_arguments
+        (user_type
+          (type_identifier))))))
 
-===
+================================================================================
 Metatypes
-===
+================================================================================
 
 _ = foo as [String].Type
 
@@ -231,7 +307,7 @@ protocol GetType {
    func getType() -> AnyObject.Type
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (assignment
@@ -245,12 +321,12 @@ protocol GetType {
           (user_type
             (type_identifier))))
       (navigation_suffix
-            (simple_identifier))))
-      (protocol_declaration
-        (type_identifier)
-        (protocol_body
-          (protocol_function_declaration
-            (simple_identifier)
-            (user_type
-              (type_identifier)
-              (type_identifier))))))
+        (simple_identifier))))
+  (protocol_declaration
+    (type_identifier)
+    (protocol_body
+      (protocol_function_declaration
+        (simple_identifier)
+        (user_type
+          (type_identifier)
+          (type_identifier))))))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "experimental-tree-sitter-swift",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "experimental-tree-sitter-swift",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "An experimental tree-sitter grammar for the Swift programming language.",
   "main": "bindings/node/index.js",
   "scripts": {

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -17,11 +17,11 @@
 
 (function_declaration (simple_identifier) @function.method)
 (function_declaration ["init" @constructor])
-(external_parameter_name) @parameter
 (throws) @keyword
 (async) @keyword
 (where_keyword) @keyword
-(parameter (simple_identifier) @parameter)
+(parameter external_name: (simple_identifier) @parameter)
+(parameter name: (simple_identifier) @parameter)
 (type_parameter (type_identifier) @parameter)
 (inheritance_constraint (identifier (simple_identifier) @parameter))
 (equality_constraint (identifier (simple_identifier) @parameter))

--- a/test-npm-package/package-lock.json
+++ b/test-npm-package/package-lock.json
@@ -14,7 +14,7 @@
       }
     },
     "..": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -24,7 +24,7 @@
         "@types/node": "^16.11.10",
         "node-gyp": "^8.4.1",
         "prettier": "2.3.2",
-        "tree-sitter-cli": "^0.20.1",
+        "tree-sitter-cli": "^0.20.0",
         "typescript": "^4.5.2"
       }
     },
@@ -700,7 +700,7 @@
         "nan": "^2.15.0",
         "node-gyp": "^8.4.1",
         "prettier": "2.3.2",
-        "tree-sitter-cli": "^0.20.1",
+        "tree-sitter-cli": "^0.20.0",
         "typescript": "^4.5.2"
       }
     },


### PR DESCRIPTION
Some minor fixups from trying to use the parser, mainly adding fields
for the elements of most common nodes. Also some minor rearranging of
the AST: things like putting external parameter names within the
parameter nodes, rather than right before, which are non-backwards
compatible so it's best to do them early.

The corpus really didn't change much, but `tree-sitter test -u`
reformatted it. This is a one-time cost and now that we're using the
auto-updated formatting, the diffs will be much cleaner from now on.

Includes a version bump to `0.0.2`, which is good because it's an
opportunity to republish the package with the publishing fixes from #93.
