### PR TITLE
Add field names to a few more nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "experimental-tree-sitter-swift"
 description = "swift grammar for the tree-sitter parsing library"
-version = "0.0.2"
+version = "0.0.3"
 keywords = ["incremental", "parsing", "swift"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/alex-pinkus/experimental-tree-sitter-swift"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use this parser to parse Swift code, you'll want to depend on either the Rust
 To use the Rust crate, you'll add this to your `Cargo.toml`:
 ```
 tree-sitter = "0.20.0"
-experimental-tree-sitter-swift = "=0.0.2"
+experimental-tree-sitter-swift = "=0.0.3"
 ```
 
 Then you can use a `tree-sitter` parser with the language declared here:
@@ -36,7 +36,7 @@ let tree = parser.parse(&my_source_code, None)
 To use this from NPM, you'll add similar dependencies to `package.json`:
 ```
 "dependencies: {
-  "experimental-tree-sitter-swift": "0.0.2",
+  "experimental-tree-sitter-swift": "0.0.3",
   "tree-sitter": "^0.20.0"
 }
 ```

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -61,7 +61,7 @@ mod tests {
             .ok_or_else(|| anyhow!("Unable to parse!"))?;
 
         assert_eq!(
-            "(source_file (assignment target: (directly_assignable_expression (simple_identifier)) result: (line_string_literal (line_str_text))))",
+            "(source_file (assignment target: (directly_assignable_expression (simple_identifier)) result: (line_string_literal text: (line_str_text))))",
             tree.root_node().to_sexp(),
         );
 

--- a/corpus/classes.txt
+++ b/corpus/classes.txt
@@ -559,10 +559,11 @@ var propertyMap: NodePropertyMap & KeypathSearchable {
       (non_binding_pattern
         (simple_identifier)))
     (type_annotation
-      (user_type
-        (type_identifier))
-      (user_type
-        (type_identifier)))
+      (protocol_composition_type
+        (user_type
+          (type_identifier))
+        (user_type
+          (type_identifier))))
     (computed_property
       (statements
         (control_transfer_statement
@@ -731,10 +732,11 @@ class SomeClassWithAlias: NSObject {
     (class_body
       (typealias_declaration
         (type_identifier)
-        (user_type
-          (type_identifier))
-        (user_type
-          (type_identifier))))))
+        (protocol_composition_type
+          (user_type
+            (type_identifier))
+          (user_type
+            (type_identifier)))))))
 
 ================================================================================
 Special constructors
@@ -1216,18 +1218,20 @@ let result: HasGeneric<P1 & P2> = HasGeneric<P1 & P2>(t: "Hello")
       (user_type
         (type_identifier)
         (type_arguments
-          (user_type
-            (type_identifier))
-          (user_type
-            (type_identifier)))))
+          (protocol_composition_type
+            (user_type
+              (type_identifier))
+            (user_type
+              (type_identifier))))))
     (constructor_expression
       (user_type
         (type_identifier)
         (type_arguments
-          (user_type
-            (type_identifier))
-          (user_type
-            (type_identifier))))
+          (protocol_composition_type
+            (user_type
+              (type_identifier))
+            (user_type
+              (type_identifier)))))
       (constructor_suffix
         (value_arguments
           (value_argument
@@ -1266,10 +1270,11 @@ func iterate<S>(h: S) where S : Sequence, S.Element == P1 & P2 { }
           (identifier
             (simple_identifier)
             (simple_identifier))
-          (user_type
-            (type_identifier))
-          (user_type
-            (type_identifier)))))
+          (protocol_composition_type
+            (user_type
+              (type_identifier))
+            (user_type
+              (type_identifier))))))
     (function_body)))
 
 ================================================================================
@@ -1289,10 +1294,11 @@ enum Foo {
       (enum_entry
         (simple_identifier)
         (enum_type_parameters
-          (user_type
-            (type_identifier))
-          (user_type
-            (type_identifier)))))))
+          (protocol_composition_type
+            (user_type
+              (type_identifier))
+            (user_type
+              (type_identifier))))))))
 
 ================================================================================
 Protocol composition in as expressions
@@ -1316,10 +1322,11 @@ let result = greet("me") as P1 & P2
               (line_string_literal
                 (line_str_text))))))
       (as_operator)
-      (user_type
-        (type_identifier))
-      (user_type
-        (type_identifier)))))
+      (protocol_composition_type
+        (user_type
+          (type_identifier))
+        (user_type
+          (type_identifier))))))
 
 ================================================================================
 Modify declarations

--- a/corpus/functions.txt
+++ b/corpus/functions.txt
@@ -782,10 +782,11 @@ func multipleType() -> Foo & Bar { return Foo() }
           (line_string_literal)))))
   (function_declaration
     (simple_identifier)
-    (user_type
-      (type_identifier))
-    (user_type
-      (type_identifier))
+    (protocol_composition_type
+      (user_type
+        (type_identifier))
+      (user_type
+        (type_identifier)))
     (function_body
       (statements
         (control_transfer_statement

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "experimental-tree-sitter-swift",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "An experimental tree-sitter grammar for the Swift programming language.",
   "main": "bindings/node/index.js",
   "scripts": {

--- a/test-npm-package/index.js
+++ b/test-npm-package/index.js
@@ -20,6 +20,6 @@ console.log(tree.rootNode.toString());
 const assert = require("assert");
 const smallTree = parser.parse(`_ = "Hello!"\n`);
 assert.equal(
-  `(source_file (assignment target: (directly_assignable_expression (simple_identifier)) result: (line_string_literal (line_str_text))))`,
+  `(source_file (assignment target: (directly_assignable_expression (simple_identifier)) result: (line_string_literal text: (line_str_text))))`,
   smallTree.rootNode.toString()
 );

--- a/test-npm-package/package-lock.json
+++ b/test-npm-package/package-lock.json
@@ -14,7 +14,7 @@
       }
     },
     "..": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
In advance of reaching 0.1, adding a few more field names should make
stability guarantees easier to satisfy.

Also promotes `protocol_composition_type` to named which breaks semver,
so bumping to 0.0.3.
